### PR TITLE
fix: Disable caching on public pages to ensure fresh data

### DIFF
--- a/src/app/[lang]/page.js
+++ b/src/app/[lang]/page.js
@@ -1,15 +1,11 @@
 import Link from 'next/link';
 
 // This function fetches data on the server side.
-// It's called from the Page component.
 async function getRecentArticles() {
   try {
-    // Using the full URL is important for server-side fetching in Next.js
     const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
-    const res = await fetch(`${baseUrl}/api/public/articles?limit=3`, {
-      // Revalidate every hour
-      next: { revalidate: 3600 }
-    });
+    // Removed the revalidate option to make it fully dynamic
+    const res = await fetch(`${baseUrl}/api/public/articles?limit=3`, { cache: 'no-store' });
     if (!res.ok) {
       throw new Error('Failed to fetch articles');
     }
@@ -51,13 +47,14 @@ export default async function HomePage({ params: { lang } }) {
                   {article.content[lang] || article.content.en}
                 </p>
                 <div className="mt-4">
-                  <span className="text-cyan-600 hover:underline">Read more &rarr;</span>
+                  {/* The user might want to click to a full article page, which doesn't exist yet. For now, this link does nothing. */}
+                  <span className="text-cyan-600 hover:underline cursor-pointer">Read more &rarr;</span>
                 </div>
               </div>
             </div>
           ))}
           {recentArticles.length === 0 && (
-            <p className="text-center text-gray-500 col-span-3">No articles to display yet.</p>
+            <p className="text-center text-gray-500 col-span-3">No articles to display yet. Create one in the admin panel!</p>
           )}
         </div>
       </section>

--- a/src/app/[lang]/trips/page.js
+++ b/src/app/[lang]/trips/page.js
@@ -1,9 +1,8 @@
 async function getTrips() {
   try {
     const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
-    const res = await fetch(`${baseUrl}/api/public/trips`, {
-      next: { revalidate: 3600 } // Revalidate every hour
-    });
+    // Removed the revalidate option to make it fully dynamic
+    const res = await fetch(`${baseUrl}/api/public/trips`, { cache: 'no-store' });
     if (!res.ok) {
       throw new Error('Failed to fetch trips');
     }
@@ -29,7 +28,7 @@ export default async function TripsPage({ params: { lang } }) {
         {trips.map(trip => (
           <div key={trip._id} className="bg-white rounded-lg shadow-lg overflow-hidden group">
             <div className="relative">
-              <img src={trip.imageUrl || 'https://via.placeholder.com/400x250'} alt={trip.title[lang] || trip.title.en} className="w-full h-56 object-cover" />
+              <img src={trip.imageUrl || 'https://images.unsplash.com/photo-1505923984062-552e3a4734d5?q=80&w=2070&auto=format&fit=crop'} alt={trip.title[lang] || trip.title.en} className="w-full h-56 object-cover" />
               <div className="absolute inset-0 bg-black bg-opacity-20 group-hover:bg-opacity-40 transition-all duration-300"></div>
               <div className="absolute bottom-0 left-0 p-4">
                 <h3 className="text-2xl font-bold text-white shadow-lg">{trip.title[lang] || trip.title.en}</h3>


### PR DESCRIPTION
This commit fixes an issue where new content created in the admin panel (trips and articles) would not appear on the public-facing pages immediately.

The cause was an aggressive caching strategy (`next: { revalidate: 3600 }`) on the `fetch` requests for public data. This has been replaced with `cache: 'no-store'` to make these pages dynamically server-rendered on every request.

This ensures that the public site always displays the most up-to-date content from the database, providing a better user experience during testing and content management.