### PR TITLE
revert: Remove rich text editor to fix critical build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "bcryptjs": "^2.4.3",
     "jsonwebtoken": "^9.0.2",
     "jose": "^5.4.1",
-    "dotenv": "^16.4.5",
-    "react-quill": "^2.0.0"
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "postcss": "^8",

--- a/src/app/fonok/layout.js
+++ b/src/app/fonok/layout.js
@@ -3,7 +3,6 @@
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
 import "../globals.css"; // Import global styles
-// The react-quill CSS is now loaded via a <link> tag in the <head> below
 
 export default function AdminLayout({ children }) {
   const router = useRouter();
@@ -35,10 +34,6 @@ export default function AdminLayout({ children }) {
     <html lang="en">
       <head>
         <title>Admin Panel</title>
-        <link
-          rel="stylesheet"
-          href="https://unpkg.com/react-quill@2.0.0/dist/quill.snow.css"
-        />
       </head>
       <body>
         <div className="flex h-screen bg-gray-100">

--- a/src/components/admin/ArticleForm.js
+++ b/src/components/admin/ArticleForm.js
@@ -1,10 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import dynamic from 'next/dynamic';
-
-// CSS is now loaded in the root admin layout via a <link> tag
-const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
 
 const languages = [
   { code: 'en', name: 'English' },
@@ -25,18 +21,11 @@ export default function ArticleForm({ initialData, onSubmit, isSaving }) {
   });
   const [currentLang, setCurrentLang] = useState('en');
 
-  const handleContentChange = (content) => {
+  const handleChange = (e) => {
+    const { name, value } = e.target;
     setArticle(prev => ({
       ...prev,
-      content: { ...prev.content, [currentLang]: content }
-    }));
-  };
-
-  const handleTitleChange = (e) => {
-    const { value } = e.target;
-    setArticle(prev => ({
-      ...prev,
-      title: { ...prev.title, [currentLang]: value }
+      [name]: { ...prev[name], [currentLang]: value }
     }));
   };
 
@@ -75,27 +64,28 @@ export default function ArticleForm({ initialData, onSubmit, isSaving }) {
             name="title"
             id="title"
             value={article.title[currentLang]}
-            onChange={handleTitleChange}
+            onChange={handleChange}
             className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-cyan-500 focus:border-cyan-500"
             required
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700">
+          <label htmlFor="content" className="block text-sm font-medium text-gray-700">
             Content ({languages.find(l => l.code === currentLang).name})
           </label>
-          <div className="mt-1 h-64 bg-white">
-            <ReactQuill
-              theme="snow"
-              value={article.content[currentLang]}
-              onChange={handleContentChange}
-              className="h-full"
-            />
-          </div>
+          <textarea
+            name="content"
+            id="content"
+            rows="12"
+            value={article.content[currentLang]}
+            onChange={handleChange}
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-cyan-500 focus:border-cyan-500"
+            required
+          />
         </div>
       </div>
 
-      <div className="flex justify-end pt-8">
+      <div className="flex justify-end">
         <button
           type="submit"
           disabled={isSaving}

--- a/src/components/admin/TripForm.js
+++ b/src/components/admin/TripForm.js
@@ -1,10 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import dynamic from 'next/dynamic';
-
-// CSS is now loaded in the root admin layout via a <link> tag
-const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
 
 const languages = [
   { code: 'en', name: 'English (British/International)' },
@@ -49,10 +45,6 @@ export default function TripForm({ initialData, onSubmit, isSaving }) {
   const handleMultilingualChange = (e) => {
     const { name, value } = e.target;
     setTrip(prev => ({ ...prev, [name]: { ...prev[name], [currentLang]: value } }));
-  };
-
-  const handleDescriptionChange = (content) => {
-    setTrip(prev => ({ ...prev, description: { ...prev.description, [currentLang]: content } }));
   };
 
   const handlePriceChange = (e) => {
@@ -112,12 +104,17 @@ export default function TripForm({ initialData, onSubmit, isSaving }) {
           <input type="text" name="title" id="title" value={trip.title[currentLang]} onChange={handleMultilingualChange} className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm" required />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700">Description ({languages.find(l => l.code === currentLang).name})</label>
-          <div className="mt-1 h-64 bg-white"><ReactQuill theme="snow" value={trip.description[currentLang]} onChange={handleDescriptionChange} className="h-full" /></div>
+          <label htmlFor="description" className="block text-sm font-medium text-gray-700">Description ({languages.find(l => l.code === currentLang).name})</label>
+          <textarea
+            name="description"
+            id="description"
+            rows="10"
+            value={trip.description[currentLang]}
+            onChange={handleMultilingualChange}
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm"
+          />
         </div>
       </div>
-
-      <div className="pt-8"></div>
 
       {/* Prices Section */}
       <div className="border-t pt-8">


### PR DESCRIPTION
This commit reverts the addition of the `react-quill` rich text editor feature. This feature introduced a `Module not found` error during the build process that proved difficult to resolve in the user's environment.

To ensure the application is stable and usable, the following changes have been made:
- The `react-quill` dependency has been removed from `package.json`.
- The admin forms (`TripForm.js` and `ArticleForm.js`) have been reverted to use standard `<textarea>` elements for content and description fields.
- The admin layout (`/fonok/layout.js`) has been reverted to remove the CSS import for the editor.

This change sacrifices the rich text editing feature in favor of a guaranteed stable and working application. All other features, including the expanded multi-language and multi-currency systems, remain intact.