### PR TITLE
feat: Update price formatting and language selector UI

### DIFF
--- a/src/components/admin/TripForm.js
+++ b/src/components/admin/TripForm.js
@@ -20,12 +20,12 @@ const emptyPrices = { eur: 0, gbp: 0, huf: 0, rub: 0, czk: 0, uah: 0 };
 const conversionRates = { eur: 1, gbp: 0.85, huf: 400, rub: 90, czk: 25, uah: 42 };
 
 const priceFormatRules = {
-  huf: (p) => Math.round(p / 1000) * 1000 - 10,
+  huf: (p) => Math.round(p / 1000) * 1000 - 10, // e.g. 12345 -> 12000 -> 11990
   eur: (p) => Math.floor(p) + 0.99,
   gbp: (p) => Math.floor(p) + 0.99,
-  rub: (p) => Math.floor(p) + 9.99,
+  rub: (p) => Math.floor(p / 100) * 100 + 99, // e.g. 1234 -> 1200 -> 1299
   czk: (p) => Math.floor(p) + 0.99,
-  uah: (p) => Math.floor(p) + 9.99,
+  uah: (p) => Math.floor(p) + 0.99, // UAH uses ,99 formatting, but the logic is the same as EUR
 };
 
 export default function TripForm({ initialData, onSubmit, isSaving }) {

--- a/src/components/public/LanguageSelector.js
+++ b/src/components/public/LanguageSelector.js
@@ -50,7 +50,7 @@ export default function LanguageSelector() {
     <div className="relative" ref={wrapperRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-between w-56 px-3 py-2 text-gray-700 bg-white border rounded-md shadow-sm"
+        className="flex items-center justify-between w-64 px-3 py-2 text-gray-700 bg-white border rounded-md shadow-sm"
       >
         <div className="flex items-center gap-2 overflow-hidden">
           {currentLang.flags.map(code => <Flag key={code} code={code} />)}


### PR DESCRIPTION
This commit implements the final set of change requests from the user, refining the currency and internationalization features.

**Changes:**
- **Price Formatting:** The `priceFormatRules` in the admin trip form have been updated to match the user's specific requirements for Russian Ruble (RUB) and Ukrainian Hryvnia (UAH) prices. RUB prices are now formatted to end in `99`, and UAH prices to end in `.99`.
- **Language Selector UI:** The width of the language selector dropdown button has been increased to `w-64` to prevent the "British/International" text from being cut off, improving the UI presentation.