### PR TITLE
fix: Add missing @tiptap/extension-image dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "@tiptap/starter-kit": "^2.4.0",
     "@tiptap/extension-text-align": "^2.4.0",
     "@tiptap/extension-text-style": "^2.4.0",
-    "@tiptap/extension-color": "^2.4.0"
+    "@tiptap/extension-color": "^2.4.0",
+    "@tiptap/extension-image": "^2.4.0"
   },
   "devDependencies": {
     "postcss": "^8",


### PR DESCRIPTION
This commit fixes a critical build error (`Module not found`) that occurred because the `@tiptap/extension-image` package was being imported in the `RichTextEditor` component but was never added to the `package.json` dependency list.

This oversight was the root cause of the persistent build failures. Adding the package to the dependencies ensures that `npm install` will correctly fetch the module, resolving the error.