### PR TITLE
fix: Add missing @tailwindcss/typography dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "tailwindcss": "^3.4.1",
     "autoprefixer": "^10.0.1",
     "eslint": "^8",
-    "eslint-config-next": "14.2.3"
+    "eslint-config-next": "14.2.3",
+    "@tailwindcss/typography": "^0.5.13"
   }
 }


### PR DESCRIPTION
This commit fixes a critical build error (`Module not found`) that occurred because the `@tailwindcss/typography` plugin was being used in `tailwind.config.js` but was never added to the `package.json` dependency list.

This oversight was the root cause of the build failure when trying to render pages with rich text content. Adding the package to the `devDependencies` ensures that `npm install` will correctly fetch the module, resolving the error.