### PR TITLE
fix: Revert admin UI header font to Arial

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
   --color-primary: #0891b2;
   --color-background: #ffffff;
   --color-text: #1f2937;
-  --font-header: 'Georgia', serif;
+  --font-header: 'Arial', sans-serif;
   --font-body: 'Arial', sans-serif;
 }
 


### PR DESCRIPTION
This commit changes the header font in the admin UI back to Arial, as per user feedback. The `--font-header` CSS variable in `globals.css` has been updated.