### PR TITLE
feat: Extend theme switcher to public-facing site

### DIFF
--- a/src/app/[lang]/layout.js
+++ b/src/app/[lang]/layout.js
@@ -1,10 +1,8 @@
 import "../globals.css";
-import Header from "@/components/public/Header";
-import CompactHeader from "@/components/public/CompactHeader";
-import Footer from "@/components/public/Footer";
 import { getTranslations } from "@/lib/getTranslations";
 import dbConnect from "@/lib/dbConnect";
 import SiteSettings from "@/models/SiteSettings";
+import PublicLayoutClient from "@/components/public/PublicLayoutClient";
 
 export const metadata = {
   title: "Train.Travel - Your Journey Begins Here",
@@ -15,67 +13,42 @@ async function getStyleSettings() {
   try {
     await dbConnect();
     const settings = await SiteSettings.findOne({}).lean();
-    return settings?.style || {
-      themeName: 'Default',
-      primaryColor: '#0891b2',
-      backgroundColor: '#FFFFFF',
-      textColor: '#1f2937',
-      headerFont: 'Georgia, serif',
-      bodyFont: 'Arial, sans-serif',
+    // Return a combination of saved style and appearance
+    return {
+      style: settings?.style || {
+        themeName: 'Default',
+        primaryColor: '#0891b2',
+        backgroundColor: '#FFFFFF',
+        textColor: '#1f2937',
+        headerFont: 'Georgia, serif',
+        bodyFont: 'Arial, sans-serif',
+      },
+      appearance: settings?.appearance || 'default'
     };
   } catch (error) {
     console.error("Failed to fetch style settings:", error);
+    // Return default values for both
     return {
-      themeName: 'Default',
-      primaryColor: '#0891b2',
-      backgroundColor: '#FFFFFF',
-      textColor: '#1f2937',
-      headerFont: 'Georgia, serif',
-      bodyFont: 'Arial, sans-serif',
+      style: {
+        themeName: 'Default',
+        primaryColor: '#0891b2',
+        backgroundColor: '#FFFFFF',
+        textColor: '#1f2937',
+        headerFont: 'Georgia, serif',
+        bodyFont: 'Arial, sans-serif',
+      },
+      appearance: 'default'
     };
   }
 }
 
 export default async function RootLayout({ children, params }) {
   const t = await getTranslations(params.lang);
-  const style = await getStyleSettings();
-
-  const headerFontUrl = `https://fonts.googleapis.com/css2?family=${style.headerFont.split(',')[0].replace(/"/g, '').replace(/ /g, '+')}:wght@700&display=swap`;
-  const bodyFontUrl = `https://fonts.googleapis.com/css2?family=${style.bodyFont.split(',')[0].replace(/"/g, '').replace(/ /g, '+')}&display=swap`;
-
-  const themeName = style.themeName.toLowerCase();
-  const mainContentClass = themeName === 'compact' ? 'ml-64' : '';
+  const settings = await getStyleSettings();
 
   return (
-    <html lang={params.lang}>
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
-        <link href={headerFontUrl} rel="stylesheet" />
-        <link href={bodyFontUrl} rel="stylesheet" />
-        <style dangerouslySetInnerHTML={{ __html: `
-          :root {
-            --color-primary: ${style.primaryColor};
-            --color-background: ${style.backgroundColor};
-            --color-text: ${style.textColor};
-            --font-header: "${style.headerFont.split(',')[0]}", ${style.headerFont.split(',').slice(1).join(',')};
-            --font-body: "${style.bodyFont.split(',')[0]}", ${style.bodyFont.split(',').slice(1).join(',')};
-          }
-        `}} />
-      </head>
-      <body className={`bg-background text-text font-body theme-${themeName}`}>
-        {themeName === 'compact'
-          ? <CompactHeader lang={params.lang} t={t.header} />
-          : <Header lang={params.lang} t={t.header} />
-        }
-        <div className={mainContentClass}>
-          <main className="flex-grow container mx-auto px-6 py-12">
-            {children}
-          </main>
-          {/* Footer is part of the main content div now, so it's not overlapped by the compact header */}
-          <Footer t={t.footer} />
-        </div>
-      </body>
-    </html>
+    <PublicLayoutClient lang={params.lang} t={t} style={settings.style}>
+      {children}
+    </PublicLayoutClient>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,3 +48,19 @@
     color: var(--color-primary);
   }
 }
+
+/* --- Public Site Themes --- */
+
+/* --- Theme: Compact --- */
+.theme-compact main {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+/* --- Theme: Playful --- */
+.theme-playful a, .theme-playful button {
+  transition: transform 0.2s cubic-bezier(.34,1.56,.64,1);
+}
+.theme-playful a:hover, .theme-playful button:hover {
+  transform: scale(1.05);
+}

--- a/src/components/public/Footer.js
+++ b/src/components/public/Footer.js
@@ -1,6 +1,18 @@
+'use client';
+
+import { useAppearance } from '@/components/admin/AppearanceSettings';
+
 export default function Footer({ t }) {
+  const { appearance } = useAppearance();
+
+  const footerClasses = {
+    default: "bg-gray-800 text-white mt-auto",
+    compact: "bg-gray-800 text-white mt-auto py-4",
+    playful: "bg-indigo-800 text-white mt-auto border-t-8 border-indigo-500 rounded-t-3xl",
+  };
+
   return (
-    <footer className="bg-gray-800 text-white mt-auto">
+    <footer className={footerClasses[appearance] || footerClasses.default}>
       <div className="container mx-auto px-6 py-8">
         <div className="flex flex-col items-center text-center">
           <h2 className="text-2xl font-bold">TRAIN.TRAVEL</h2>

--- a/src/components/public/PublicLayoutClient.js
+++ b/src/components/public/PublicLayoutClient.js
@@ -1,0 +1,74 @@
+'use client';
+
+import { AppearanceProvider, useAppearance } from '@/components/admin/AppearanceSettings';
+import Header from "@/components/public/Header";
+import CompactHeader from "@/components/public/CompactHeader";
+import Footer from "@/components/public/Footer";
+
+// This new component will be the consumer of the context
+// and can safely call the useAppearance hook.
+function AppBody({ lang, t, children }) {
+  const { appearance, isLoading } = useAppearance();
+
+  // We can show a loading state or a default state while the theme is being determined client-side
+  if (isLoading) {
+    // Render a default, non-themed layout to prevent layout shifts
+    return (
+      <body className="bg-background text-text font-body theme-default">
+        <Header lang={lang} t={t.header} />
+        <main className="flex-grow container mx-auto px-6 py-12">
+          {children}
+        </main>
+        <Footer t={t.footer} />
+      </body>
+    );
+  }
+
+  const mainContentClass = appearance === 'compact' ? 'ml-64' : '';
+
+  return (
+    <body className={`bg-background text-text font-body theme-${appearance}`}>
+      {appearance === 'compact'
+        ? <CompactHeader lang={lang} t={t.header} />
+        : <Header lang={lang} t={t.header} />
+      }
+      <div className={mainContentClass}>
+        <main className="flex-grow container mx-auto px-6 py-12">
+          {children}
+        </main>
+        <Footer t={t.footer} />
+      </div>
+    </body>
+  );
+}
+
+
+export default function PublicLayoutClient({ lang, t, style, children }) {
+  const headerFontUrl = `https://fonts.googleapis.com/css2?family=${style.headerFont.split(',')[0].replace(/"/g, '').replace(/ /g, '+')}:wght@700&display=swap`;
+  const bodyFontUrl = `https://fonts.googleapis.com/css2?family=${style.bodyFont.split(',')[0].replace(/"/g, '').replace(/ /g, '+')}&display=swap`;
+
+  return (
+    <html lang={lang}>
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
+        <link href={headerFontUrl} rel="stylesheet" />
+        <link href={bodyFontUrl} rel="stylesheet" />
+        <style dangerouslySetInnerHTML={{ __html: `
+          :root {
+            --color-primary: ${style.primaryColor};
+            --color-background: ${style.backgroundColor};
+            --color-text: ${style.textColor};
+            --font-header: "${style.headerFont.split(',')[0]}", ${style.headerFont.split(',').slice(1).join(',')};
+            --font-body: "${style.bodyFont.split(',')[0]}", ${style.bodyFont.split(',').slice(1).join(',')};
+          }
+        `}} />
+      </head>
+      <AppearanceProvider>
+        <AppBody lang={lang} t={t}>
+          {children}
+        </AppBody>
+      </AppearanceProvider>
+    </html>
+  );
+}


### PR DESCRIPTION
This commit expands the theme switching functionality, previously only in the admin panel, to the entire public-facing website. Users can now select a 'Default', 'Compact', or 'Playful' theme from the admin styling page, and it will apply globally.

Changes:
- The main public layout (`src/app/[lang]/layout.js`) has been refactored to use a new `PublicLayoutClient.js` component, allowing a client-side `AppearanceProvider` to be used with a server component layout.
- The public `Header` is now conditionally rendered, with the `CompactHeader` being used for the 'Compact' theme.
- The public `Footer` component now uses the `useAppearance` hook to apply theme-specific styles.
- New global CSS styles have been added to `globals.css` to define the public-facing 'Compact' and 'Playful' themes.