### PR TITLE
fix: Ensure theme persistence on public site

### DIFF
--- a/src/app/[lang]/layout.js
+++ b/src/app/[lang]/layout.js
@@ -47,7 +47,12 @@ export default async function RootLayout({ children, params }) {
   const settings = await getStyleSettings();
 
   return (
-    <PublicLayoutClient lang={params.lang} t={t} style={settings.style}>
+    <PublicLayoutClient
+      lang={params.lang}
+      t={t}
+      style={settings.style}
+      initialAppearance={settings.appearance}
+    >
       {children}
     </PublicLayoutClient>
   );

--- a/src/components/admin/AppearanceSettings.js
+++ b/src/components/admin/AppearanceSettings.js
@@ -8,9 +8,10 @@ export function useAppearance() {
   return useContext(AppearanceContext);
 }
 
-export function AppearanceProvider({ children }) {
-  const [appearance, setAppearance] = useState('default');
-  const [isLoading, setIsLoading] = useState(true);
+export function AppearanceProvider({ children, initialAppearance }) {
+  const [appearance, setAppearance] = useState(initialAppearance || 'default');
+  // If we have an initial appearance, we are not loading. Otherwise, we are.
+  const [isLoading, setIsLoading] = useState(!initialAppearance);
 
   useEffect(() => {
     const fetchAppearance = async () => {
@@ -26,8 +27,12 @@ export function AppearanceProvider({ children }) {
         setIsLoading(false);
       }
     };
-    fetchAppearance();
-  }, []);
+
+    // Only fetch if we didn't get an initial value (i.e., in the admin panel)
+    if (!initialAppearance) {
+      fetchAppearance();
+    }
+  }, [initialAppearance]);
 
   const saveAppearance = async (newAppearance) => {
     try {

--- a/src/components/public/PublicLayoutClient.js
+++ b/src/components/public/PublicLayoutClient.js
@@ -43,7 +43,7 @@ function AppBody({ lang, t, children }) {
 }
 
 
-export default function PublicLayoutClient({ lang, t, style, children }) {
+export default function PublicLayoutClient({ lang, t, style, initialAppearance, children }) {
   const headerFontUrl = `https://fonts.googleapis.com/css2?family=${style.headerFont.split(',')[0].replace(/"/g, '').replace(/ /g, '+')}:wght@700&display=swap`;
   const bodyFontUrl = `https://fonts.googleapis.com/css2?family=${style.bodyFont.split(',')[0].replace(/"/g, '').replace(/ /g, '+')}&display=swap`;
 
@@ -64,7 +64,7 @@ export default function PublicLayoutClient({ lang, t, style, children }) {
           }
         `}} />
       </head>
-      <AppearanceProvider>
+      <AppearanceProvider initialAppearance={initialAppearance}>
         <AppBody lang={lang} t={t}>
           {children}
         </AppBody>


### PR DESCRIPTION
This commit fixes a bug where the selected theme was not persisting correctly on the public-facing site.

The root cause was that the public site layout was attempting to fetch the theme settings via a protected API endpoint without being authenticated.

The fix involves the following changes:
- The `AppearanceProvider` is now able to accept an `initialAppearance` prop, allowing it to be initialized with a theme from the server.
- The main public layout (`src/app/[lang]/layout.js`) now fetches the appearance setting on the server and passes it down as a prop to the `PublicLayoutClient`.
- The `PublicLayoutClient` then uses this prop to initialize the `AppearanceProvider`, eliminating the need for a separate, failing client-side API call.

This ensures the selected theme is applied immediately on page load and persists correctly for all users.