### PR TITLE
feat: Redesign public site themes based on user feedback

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,9 +58,18 @@
 }
 
 /* --- Theme: Playful --- */
+.theme-playful {
+  --color-background: #fffef5;
+  --font-header: 'Comic Sans MS', cursive;
+}
 .theme-playful a, .theme-playful button {
   transition: transform 0.2s cubic-bezier(.34,1.56,.64,1);
 }
 .theme-playful a:hover, .theme-playful button:hover {
-  transform: scale(1.05);
+  transform: scale(1.05) rotate(-1deg);
+}
+.theme-playful img {
+  border: 4px solid white;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  border-radius: 8px;
 }

--- a/src/components/public/Header.js
+++ b/src/components/public/Header.js
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import TrainLogo from './TrainLogo';
 import LanguageSelector from './LanguageSelector';
 
-export default function Header({ lang, t }) {
+export default function Header({ lang, t, appearance }) {
   const [isScrolled, setIsScrolled] = useState(false);
 
   useEffect(() => {
@@ -16,8 +16,10 @@ export default function Header({ lang, t }) {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  const headerPadding = appearance === 'compact' ? 'py-2' : (isScrolled ? 'py-2' : 'py-4');
+
   return (
-    <header className={`bg-white shadow-md sticky top-0 z-50 transition-all duration-300 ${isScrolled ? 'py-2' : 'py-4'}`}>
+    <header className={`bg-white shadow-md sticky top-0 z-50 transition-all duration-300 ${headerPadding}`}>
       <div className="container mx-auto px-6 flex justify-between items-center">
         <TrainLogo lang={lang} />
 

--- a/src/components/public/PlayfulHeader.js
+++ b/src/components/public/PlayfulHeader.js
@@ -1,0 +1,36 @@
+'use client';
+
+import Link from 'next/link';
+import TrainLogo from './TrainLogo';
+import LanguageSelector from './LanguageSelector';
+
+export default function PlayfulHeader({ lang, t }) {
+  const navLinks = [
+    { href: `/${lang}`, label: t.home },
+    { href: `/${lang}/pricing`, label: t.pricing },
+    { href: `/${lang}/trips`, label: t.trips },
+    { href: `/${lang}/articles`, label: t.articles },
+    { href: `/${lang}/about`, label: t.about },
+    { href: `/${lang}/contact`, label: t.contact },
+  ];
+
+  return (
+    <aside className="bg-indigo-800 text-white w-64 h-full fixed top-0 left-0 overflow-y-auto z-50 p-6 flex flex-col transform -rotate-2 -ml-2">
+      <div className="flex-shrink-0 mb-8">
+        <TrainLogo lang={lang} />
+      </div>
+
+      <nav className="flex-grow space-y-3">
+        {navLinks.map(link => (
+          <Link key={link.href} href={link.href} className="block text-lg py-2 px-4 rounded-lg hover:bg-indigo-700 transition-colors duration-200">
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+
+      <div className="flex-shrink-0 mt-8">
+        <LanguageSelector />
+      </div>
+    </aside>
+  );
+}

--- a/src/components/public/PublicLayoutClient.js
+++ b/src/components/public/PublicLayoutClient.js
@@ -2,7 +2,7 @@
 
 import { AppearanceProvider, useAppearance } from '@/components/admin/AppearanceSettings';
 import Header from "@/components/public/Header";
-import CompactHeader from "@/components/public/CompactHeader";
+import PlayfulHeader from "@/components/public/PlayfulHeader";
 import Footer from "@/components/public/Footer";
 
 // This new component will be the consumer of the context
@@ -24,14 +24,18 @@ function AppBody({ lang, t, children }) {
     );
   }
 
-  const mainContentClass = appearance === 'compact' ? 'ml-64' : '';
+  const mainContentClass = appearance === 'playful' ? 'ml-64' : '';
+
+  const renderHeader = () => {
+    if (appearance === 'playful') {
+      return <PlayfulHeader lang={lang} t={t.header} />;
+    }
+    return <Header lang={lang} t={t.header} appearance={appearance} />;
+  };
 
   return (
     <body className={`bg-background text-text font-body theme-${appearance}`}>
-      {appearance === 'compact'
-        ? <CompactHeader lang={lang} t={t.header} />
-        : <Header lang={lang} t={t.header} />
-      }
+      {renderHeader()}
       <div className={mainContentClass}>
         <main className="flex-grow container mx-auto px-6 py-12">
           {children}


### PR DESCRIPTION
This commit implements a major redesign of the 'Compact' and 'Playful' themes for the public-facing site, as per user requests.

Compact Theme Changes:
- The theme no longer uses a sidebar.
- The standard top `Header` is now made more compact by reducing its padding, saving vertical space while maintaining the standard layout.

Playful Theme Changes:
- A new `PlayfulHeader` component has been created, which implements a fixed, left-aligned, slightly rotated sidebar menu, similar to the admin panel's playful theme.
- The main site layout now uses this sidebar when the 'playful' theme is active.
- Additional playful styles (e.g., a whimsical font, image borders) have been added to `globals.css` to enhance the theme's appearance.