### PR TITLE
feat: Add loading indicators to Single Page theme

### DIFF
--- a/src/components/public/LoadingSpinner.js
+++ b/src/components/public/LoadingSpinner.js
@@ -1,0 +1,7 @@
+export default function LoadingSpinner() {
+  return (
+    <div className="flex justify-center items-center p-8">
+      <div className="w-16 h-16 border-4 border-dashed rounded-full animate-spin border-primary"></div>
+    </div>
+  );
+}

--- a/src/components/public/SinglePage.js
+++ b/src/components/public/SinglePage.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
+import LoadingSpinner from './LoadingSpinner';
 
 // A reusable component to animate sections as they scroll into view
 function AnimatedSection({ children }) {
@@ -45,7 +46,7 @@ function PricingSection({ t }) {
   );
 }
 
-function TripsSection({ trips, lang, t }) {
+function TripsSection({ trips, isLoading, lang, t }) {
   const getPriceDisplay = (prices) => {
     if (!prices) return 'Price not set';
     if (lang === 'en') {
@@ -62,59 +63,63 @@ function TripsSection({ trips, lang, t }) {
     <section id="trips" className="min-h-screen py-20 bg-gray-50">
       <div className="container mx-auto px-6">
         <h2 className="text-4xl font-bold text-center mb-12">{t.tripsPage.title}</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {trips.map(trip => (
-            <div key={trip._id} className="block bg-white rounded-lg shadow-lg overflow-hidden group">
-              <div className="relative">
-                <img src={trip.imageUrl || 'https://images.unsplash.com/photo-1505923984062-552e3a4734d5?q=80&w=2070&auto=format&fit=crop'} alt={trip.title[lang] || trip.title.en} className="w-full h-56 object-cover transition-transform duration-300 group-hover:scale-105" />
-              </div>
-              <div className="p-6 flex flex-col">
-                <h3 className="text-2xl font-bold text-gray-900 font-header">{trip.title[lang] || trip.title.en}</h3>
-                <div
-                  className="prose text-text/80 line-clamp-4 flex-grow mt-2"
-                  dangerouslySetInnerHTML={{ __html: trip.description[lang] || trip.description.en }}
-                />
-                <div className="mt-4 flex justify-between items-center pt-4 border-t">
-                  <p className="text-lg font-bold text-primary">{getPriceDisplay(trip.prices)}</p>
-                  <span className="text-text/70 text-sm">
-                    {trip.startDate ? new Date(trip.startDate).toLocaleDateString() : ''}
-                  </span>
+        {isLoading ? <LoadingSpinner /> : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {trips.map(trip => (
+              <div key={trip._id} className="block bg-white rounded-lg shadow-lg overflow-hidden group">
+                <div className="relative">
+                  <img src={trip.imageUrl || 'https://images.unsplash.com/photo-1505923984062-552e3a4734d5?q=80&w=2070&auto=format&fit=crop'} alt={trip.title[lang] || trip.title.en} className="w-full h-56 object-cover transition-transform duration-300 group-hover:scale-105" />
+                </div>
+                <div className="p-6 flex flex-col">
+                  <h3 className="text-2xl font-bold text-gray-900 font-header">{trip.title[lang] || trip.title.en}</h3>
+                  <div
+                    className="prose text-text/80 line-clamp-4 flex-grow mt-2"
+                    dangerouslySetInnerHTML={{ __html: trip.description[lang] || trip.description.en }}
+                  />
+                  <div className="mt-4 flex justify-between items-center pt-4 border-t">
+                    <p className="text-lg font-bold text-primary">{getPriceDisplay(trip.prices)}</p>
+                    <span className="text-text/70 text-sm">
+                      {trip.startDate ? new Date(trip.startDate).toLocaleDateString() : ''}
+                    </span>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
-          {trips.length === 0 && (
-            <p className="text-center text-text/70 col-span-full">{t.tripsPage.noTrips}</p>
-          )}
-        </div>
+            ))}
+            {trips.length === 0 && (
+              <p className="text-center text-text/70 col-span-full">{t.tripsPage.noTrips}</p>
+            )}
+          </div>
+        )}
       </div>
     </section>
   );
 }
 
-function ArticlesSection({ articles, lang, t }) {
+function ArticlesSection({ articles, isLoading, lang, t }) {
   return (
     <section id="articles" className="min-h-screen py-20 bg-white">
       <div className="container mx-auto px-6">
         <h2 className="text-4xl font-bold text-center mb-12">{t.articlesPage.title}</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {articles.map(article => (
-            <div key={article._id} className="bg-white rounded-lg shadow-md overflow-hidden transform hover:-translate-y-2 transition-transform duration-300 flex flex-col">
-              <div className="p-6 flex-grow flex flex-col">
-                <p className="text-sm text-gray-500">{new Date(article.createdAt).toLocaleDateString()}</p>
-                <h3 className="text-xl font-semibold my-2">{article.title[lang] || article.title.en}</h3>
-                <div
-                  className="prose text-gray-600 line-clamp-4 flex-grow"
-                  dangerouslySetInnerHTML={{ __html: article.content[lang] || article.content.en }}
-                />
-                {/* The "Read More" link doesn't make sense in a single-page context, so it's omitted. */}
+        {isLoading ? <LoadingSpinner /> : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {articles.map(article => (
+              <div key={article._id} className="bg-white rounded-lg shadow-md overflow-hidden transform hover:-translate-y-2 transition-transform duration-300 flex flex-col">
+                <div className="p-6 flex-grow flex flex-col">
+                  <p className="text-sm text-gray-500">{new Date(article.createdAt).toLocaleDateString()}</p>
+                  <h3 className="text-xl font-semibold my-2">{article.title[lang] || article.title.en}</h3>
+                  <div
+                    className="prose text-gray-600 line-clamp-4 flex-grow"
+                    dangerouslySetInnerHTML={{ __html: article.content[lang] || article.content.en }}
+                  />
+                  {/* The "Read More" link doesn't make sense in a single-page context, so it's omitted. */}
+                </div>
               </div>
-            </div>
-          ))}
-          {articles.length === 0 && (
-            <p className="text-center text-gray-500 col-span-full">{t.homePage.noArticles}</p>
-          )}
-        </div>
+            ))}
+            {articles.length === 0 && (
+              <p className="text-center text-gray-500 col-span-full">{t.homePage.noArticles}</p>
+            )}
+          </div>
+        )}
       </div>
     </section>
   );
@@ -210,26 +215,34 @@ function SinglePageHeader({ t }) {
 export default function SinglePage({ lang, t }) {
   const [trips, setTrips] = useState([]);
   const [articles, setArticles] = useState([]);
+  const [tripsLoading, setTripsLoading] = useState(true);
+  const [articlesLoading, setArticlesLoading] = useState(true);
 
   useEffect(() => {
     async function getTrips() {
+      setTripsLoading(true);
       try {
         const res = await fetch(`/api/public/trips`);
         if (!res.ok) throw new Error('Failed to fetch trips');
         const data = await res.json();
-        setTrips(data.data);
+        setTrips(data.data || []);
       } catch (error) {
         console.error("Error fetching trips for single page:", error);
+      } finally {
+        setTripsLoading(false);
       }
     }
     async function getArticles() {
+      setArticlesLoading(true);
       try {
         const res = await fetch(`/api/public/articles`);
         if (!res.ok) throw new Error('Failed to fetch articles');
         const data = await res.json();
-        setArticles(data.data);
+        setArticles(data.data || []);
       } catch (error) {
         console.error("Error fetching articles for single page:", error);
+      } finally {
+        setArticlesLoading(false);
       }
     }
     getTrips();
@@ -241,8 +254,8 @@ export default function SinglePage({ lang, t }) {
       <SinglePageHeader t={t} />
       <HeroSection />
       <AnimatedSection><PricingSection t={t} /></AnimatedSection>
-      <AnimatedSection><TripsSection trips={trips} lang={lang} t={t} /></AnimatedSection>
-      <AnimatedSection><ArticlesSection articles={articles} lang={lang} t={t} /></AnimatedSection>
+      <AnimatedSection><TripsSection trips={trips} isLoading={tripsLoading} lang={lang} t={t} /></AnimatedSection>
+      <AnimatedSection><ArticlesSection articles={articles} isLoading={articlesLoading} lang={lang} t={t} /></AnimatedSection>
       <AnimatedSection><AboutSection t={t} /></AnimatedSection>
       <AnimatedSection><ContactSection t={t} /></AnimatedSection>
     </div>


### PR DESCRIPTION
This commit improves the user experience of the 'Single Page' theme by adding loading spinners to sections that fetch dynamic data.

Changes:
- A new reusable `LoadingSpinner` component has been created.
- The `SinglePage` component now manages loading states for the 'Trips' and 'Articles' sections.
- While data is being fetched for these sections, the `LoadingSpinner` is displayed to the user, providing clear feedback that content is on its way.