### PR TITLE
refactor: Improve performance by fetching Single Page data on server

### DIFF
--- a/src/app/[lang]/layout.js
+++ b/src/app/[lang]/layout.js
@@ -2,6 +2,8 @@ import "../globals.css";
 import { getTranslations } from "@/lib/getTranslations";
 import dbConnect from "@/lib/dbConnect";
 import SiteSettings from "@/models/SiteSettings";
+import Trip from "@/models/Trip";
+import Article from "@/models/Article";
 import PublicLayoutClient from "@/components/public/PublicLayoutClient";
 import { unstable_noStore as noStore } from 'next/cache';
 
@@ -44,9 +46,39 @@ async function getStyleSettings() {
   }
 }
 
+async function getTrips() {
+  noStore();
+  try {
+    const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
+    const res = await fetch(`${baseUrl}/api/public/trips`, { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to fetch trips');
+    const data = await res.json();
+    return data.data || [];
+  } catch (error) {
+    console.error("Error fetching trips in root layout:", error);
+    return [];
+  }
+}
+
+async function getArticles() {
+  noStore();
+  try {
+    const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
+    const res = await fetch(`${baseUrl}/api/public/articles`, { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to fetch articles');
+    const data = await res.json();
+    return data.data || [];
+  } catch (error) {
+    console.error("Error fetching articles in root layout:", error);
+    return [];
+  }
+}
+
 export default async function RootLayout({ children, params }) {
   const t = await getTranslations(params.lang);
   const settings = await getStyleSettings();
+  const trips = await getTrips();
+  const articles = await getArticles();
 
   return (
     <PublicLayoutClient
@@ -54,6 +86,8 @@ export default async function RootLayout({ children, params }) {
       t={t}
       style={settings.style}
       initialAppearance={settings.appearance}
+      trips={trips}
+      articles={articles}
     >
       {children}
     </PublicLayoutClient>

--- a/src/components/public/PublicLayoutClient.js
+++ b/src/components/public/PublicLayoutClient.js
@@ -8,7 +8,7 @@ import SinglePage from "@/components/public/SinglePage";
 
 // This new component will be the consumer of the context
 // and can safely call the useAppearance hook.
-function AppBody({ lang, t, children }) {
+function AppBody({ lang, t, trips, articles, children }) {
   const { appearance, isLoading } = useAppearance();
 
   // We can show a loading state or a default state while the theme is being determined client-side
@@ -28,7 +28,7 @@ function AppBody({ lang, t, children }) {
   if (appearance === 'single-page') {
     return (
       <body className={`bg-background text-text font-body theme-single-page`}>
-        <SinglePage lang={lang} t={t} />
+        <SinglePage lang={lang} t={t} trips={trips} articles={articles} />
       </body>
     );
   }
@@ -57,7 +57,7 @@ function AppBody({ lang, t, children }) {
 }
 
 
-export default function PublicLayoutClient({ lang, t, style, initialAppearance, children }) {
+export default function PublicLayoutClient({ lang, t, style, initialAppearance, trips, articles, children }) {
   const headerFontUrl = `https://fonts.googleapis.com/css2?family=${style.headerFont.split(',')[0].replace(/"/g, '').replace(/ /g, '+')}:wght@700&display=swap`;
   const bodyFontUrl = `https://fonts.googleapis.com/css2?family=${style.bodyFont.split(',')[0].replace(/"/g, '').replace(/ /g, '+')}&display=swap`;
 
@@ -79,7 +79,7 @@ export default function PublicLayoutClient({ lang, t, style, initialAppearance, 
         `}} />
       </head>
       <AppearanceProvider initialAppearance={initialAppearance}>
-        <AppBody lang={lang} t={t}>
+        <AppBody lang={lang} t={t} trips={trips} articles={articles}>
           {children}
         </AppBody>
       </AppearanceProvider>

--- a/src/components/public/SinglePage.js
+++ b/src/components/public/SinglePage.js
@@ -46,7 +46,7 @@ function PricingSection({ t }) {
   );
 }
 
-function TripsSection({ trips, isLoading, lang, t }) {
+function TripsSection({ trips, lang, t }) {
   const getPriceDisplay = (prices) => {
     if (!prices) return 'Price not set';
     if (lang === 'en') {
@@ -63,7 +63,7 @@ function TripsSection({ trips, isLoading, lang, t }) {
     <section id="trips" className="min-h-screen py-20 bg-gray-50">
       <div className="container mx-auto px-6">
         <h2 className="text-4xl font-bold text-center mb-12">{t.tripsPage.title}</h2>
-        {isLoading ? <LoadingSpinner /> : (
+        {(trips && trips.length > 0) ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {trips.map(trip => (
               <div key={trip._id} className="block bg-white rounded-lg shadow-lg overflow-hidden group">
@@ -85,22 +85,21 @@ function TripsSection({ trips, isLoading, lang, t }) {
                 </div>
               </div>
             ))}
-            {trips.length === 0 && (
-              <p className="text-center text-text/70 col-span-full">{t.tripsPage.noTrips}</p>
-            )}
           </div>
+        ) : (
+          <p className="text-center text-text/70 col-span-full">{t.tripsPage.noTrips}</p>
         )}
       </div>
     </section>
   );
 }
 
-function ArticlesSection({ articles, isLoading, lang, t }) {
+function ArticlesSection({ articles, lang, t }) {
   return (
     <section id="articles" className="min-h-screen py-20 bg-white">
       <div className="container mx-auto px-6">
         <h2 className="text-4xl font-bold text-center mb-12">{t.articlesPage.title}</h2>
-        {isLoading ? <LoadingSpinner /> : (
+        {(articles && articles.length > 0) ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {articles.map(article => (
               <div key={article._id} className="bg-white rounded-lg shadow-md overflow-hidden transform hover:-translate-y-2 transition-transform duration-300 flex flex-col">
@@ -111,14 +110,12 @@ function ArticlesSection({ articles, isLoading, lang, t }) {
                     className="prose text-gray-600 line-clamp-4 flex-grow"
                     dangerouslySetInnerHTML={{ __html: article.content[lang] || article.content.en }}
                   />
-                  {/* The "Read More" link doesn't make sense in a single-page context, so it's omitted. */}
                 </div>
               </div>
             ))}
-            {articles.length === 0 && (
-              <p className="text-center text-gray-500 col-span-full">{t.homePage.noArticles}</p>
-            )}
           </div>
+        ) : (
+          <p className="text-center text-gray-500 col-span-full">{t.homePage.noArticles}</p>
         )}
       </div>
     </section>
@@ -212,50 +209,14 @@ function SinglePageHeader({ t }) {
   );
 }
 
-export default function SinglePage({ lang, t }) {
-  const [trips, setTrips] = useState([]);
-  const [articles, setArticles] = useState([]);
-  const [tripsLoading, setTripsLoading] = useState(true);
-  const [articlesLoading, setArticlesLoading] = useState(true);
-
-  useEffect(() => {
-    async function getTrips() {
-      setTripsLoading(true);
-      try {
-        const res = await fetch(`/api/public/trips`);
-        if (!res.ok) throw new Error('Failed to fetch trips');
-        const data = await res.json();
-        setTrips(data.data || []);
-      } catch (error) {
-        console.error("Error fetching trips for single page:", error);
-      } finally {
-        setTripsLoading(false);
-      }
-    }
-    async function getArticles() {
-      setArticlesLoading(true);
-      try {
-        const res = await fetch(`/api/public/articles`);
-        if (!res.ok) throw new Error('Failed to fetch articles');
-        const data = await res.json();
-        setArticles(data.data || []);
-      } catch (error) {
-        console.error("Error fetching articles for single page:", error);
-      } finally {
-        setArticlesLoading(false);
-      }
-    }
-    getTrips();
-    getArticles();
-  }, []);
-
+export default function SinglePage({ lang, t, trips, articles }) {
   return (
     <div className="bg-white">
       <SinglePageHeader t={t} />
       <HeroSection />
       <AnimatedSection><PricingSection t={t} /></AnimatedSection>
-      <AnimatedSection><TripsSection trips={trips} isLoading={tripsLoading} lang={lang} t={t} /></AnimatedSection>
-      <AnimatedSection><ArticlesSection articles={articles} isLoading={articlesLoading} lang={lang} t={t} /></AnimatedSection>
+      <AnimatedSection><TripsSection trips={trips} lang={lang} t={t} /></AnimatedSection>
+      <AnimatedSection><ArticlesSection articles={articles} lang={lang} t={t} /></AnimatedSection>
       <AnimatedSection><AboutSection t={t} /></AnimatedSection>
       <AnimatedSection><ContactSection t={t} /></AnimatedSection>
     </div>


### PR DESCRIPTION
This commit refactors the data loading strategy for the 'Single Page' theme to significantly improve performance.

Previously, the `SinglePage` component fetched its data (trips, articles) on the client side after the initial page load. This created a content flash and delayed the time to interactive.

Changes:
- The main public layout (`src/app/[lang]/layout.js`) now fetches all data required for the single page theme on the server.
- This data is then passed down as props to the `SinglePage` component.
- The `SinglePage` component has been refactored to be a 'dumb' component that simply receives props and renders them, removing all client-side data fetching logic, `useEffect` hooks, and loading states.

This ensures that all content for the single page theme is now server-rendered, resulting in a much faster initial load time.