### PR TITLE
feat: Redesign appearance page and public themes

### DIFF
--- a/src/app/fonok/styling/page.js
+++ b/src/app/fonok/styling/page.js
@@ -29,6 +29,37 @@ const defaultSchemes = {
   "Plum": { primaryColor: '#a78bfa', backgroundColor: '#f5f3ff', textColor: '#1f2937' },
 };
 
+// Live Preview Component
+function LivePreview({ styleSettings }) {
+  const { primaryColor, backgroundColor, textColor, headerFont, bodyFont } = styleSettings;
+
+  const previewStyle = {
+    backgroundColor: backgroundColor,
+    color: textColor,
+    fontFamily: bodyFont,
+    borderColor: primaryColor,
+  };
+
+  const headerStyle = {
+    fontFamily: headerFont,
+    color: primaryColor,
+  };
+
+  return (
+    <div>
+      <h3 className="text-lg font-semibold mb-2">Live Preview</h3>
+      <div className="border-4 rounded-lg p-6" style={previewStyle}>
+        <h4 className="text-2xl font-bold mb-2" style={headerStyle}>A Sample Header</h4>
+        <p className="text-sm">This is some sample body text to demonstrate the selected fonts and colors. The quick brown fox jumps over the lazy dog.</p>
+        <button className="mt-4 px-4 py-2 rounded-md text-white" style={{ backgroundColor: primaryColor }}>
+          A Button
+        </button>
+      </div>
+    </div>
+  );
+}
+
+
 export default function StylingPage() {
   const [styleSettings, setStyleSettings] = useState(newDefaultStyle);
   const [isSaving, setIsSaving] = useState(false);
@@ -43,7 +74,6 @@ export default function StylingPage() {
         const res = await fetch('/api/cms/settings');
         const data = await res.json();
         if (data.success && data.data.style) {
-          // Ensure all fields are present, falling back to new defaults
           setStyleSettings({ ...newDefaultStyle, ...data.data.style });
         }
       } catch (err) {
@@ -93,14 +123,24 @@ export default function StylingPage() {
     <div className="bg-white p-8 rounded-lg shadow-md">
       <h1 className="text-2xl font-bold mb-6">Site Styling</h1>
       <div className="space-y-8">
-        <div>
-          <h3 className="text-lg font-semibold mb-2">Color Schemes</h3>
-          <div className="flex gap-4 flex-wrap">
-            {Object.keys(defaultSchemes).map(name => (
-              <button key={name} onClick={() => applyScheme(name)} className="px-4 py-2 border rounded-lg hover:bg-gray-100">{name}</button>
-            ))}
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Color scheme presets</h3>
+            <div className="flex gap-4 flex-wrap">
+              {Object.keys(defaultSchemes).map(name => (
+                <button key={name} onClick={() => applyScheme(name)} className="px-4 py-2 border rounded-lg hover:bg-gray-100">{name}</button>
+              ))}
+            </div>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Background Presets</h3>
+            <select name="backgroundColor" value={styleSettings.backgroundColor} onChange={handleChange} className="p-2 border rounded-md bg-white w-full">
+              <option value="#FFFFFF">White</option><option value="#f3f4f6">Light Gray</option><option value="#4b5563">Dark Gray</option><option value="#111827">Black</option>
+            </select>
           </div>
         </div>
+
         <div>
           <h3 className="text-lg font-semibold mb-2">Custom Colors</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -109,12 +149,9 @@ export default function StylingPage() {
             <div className="flex items-center gap-2"><label htmlFor="textColor">Text:</label><input type="color" id="textColor" name="textColor" value={styleSettings.textColor} onChange={handleChange} /></div>
           </div>
         </div>
-        <div>
-          <h3 className="text-lg font-semibold mb-2">Background Presets</h3>
-          <select name="backgroundColor" value={styleSettings.backgroundColor} onChange={handleChange} className="p-2 border rounded-md bg-white">
-            <option value="#FFFFFF">White</option><option value="#f3f4f6">Light Gray</option><option value="#4b5563">Dark Gray</option><option value="#111827">Black</option>
-          </select>
-        </div>
+
+        <LivePreview styleSettings={styleSettings} />
+
         <div>
           <h3 className="text-lg font-semibold mb-2">Fonts</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -141,7 +178,7 @@ export default function StylingPage() {
         </button>
       </div>
 
-      <hr className="my-12" />
+      <hr className="my-12 border-t-2 border-gray-200" />
 
       <AdminAppearanceEditor />
     </div>

--- a/src/components/admin/AdminAppearanceEditor.js
+++ b/src/components/admin/AdminAppearanceEditor.js
@@ -6,47 +6,48 @@ import { useAppearance } from '@/components/admin/AppearanceSettings';
 // --- SVG Illustration Generators ---
 
 const createAdminSvg = (theme) => {
-  let header, mainContent;
-  const bgColor = '#1f2937'; // Admin background
-  const primaryColor = '#4f46e5'; // A generic primary for previews
-  const textColor = '#FFFFFF';
+  const bgColor = '#1f2937';
+  const primaryColor = '#4f46e5';
+  const contentBg = '#E5E7EB';
+  const text = '#FFFFFF';
 
+  let sidebar;
   switch (theme) {
     case 'playful':
-      header = `<rect x="5" y="15" width="90" height="370" fill="${primaryColor}" rx="8" transform="rotate(-2 50 185)" />`;
-      mainContent = `<rect x="110" y="15" width="475" height="370" fill="#E5E7EB" rx="8" />`;
+      sidebar = `<g transform="rotate(-2 50 185)"><rect x="10" y="15" width="90" height="370" fill="${primaryColor}" rx="8" /><rect x="25" y="35" width="60" height="10" fill="${text}" rx="3"/><path d="M25 70 h60 M25 90 h60 M25 110 h60" stroke="${text}" stroke-width="4" stroke-linecap="round"/></g>`;
       break;
-    case 'single-page': // In admin, single-page (formerly compact) has no sidebar
-    default: // Default also has a sidebar
-      header = `<rect x="15" y="15" width="120" height="370" fill="${bgColor}" rx="8" />`;
-      mainContent = `<rect x="150" y="15" width="435" height="370" fill="#E5E7EB" rx="8" />`;
+    default:
+      sidebar = `<g><rect x="15" y="15" width="120" height="370" fill="${bgColor}" rx="8" /><rect x="30" y="35" width="90" height="12" fill="${primaryColor}" rx="4"/><path d="M30 80 h90 M30 105 h90 M30 130 h90" stroke="${text}" stroke-width="5" stroke-linecap="round"/></g>`;
       break;
   }
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400"><rect width="100%" height="100%" fill="#F3F4F6"/><g>${header}${mainContent}</g><text x="50%" y="90%" font-family="Arial" font-size="20" fill="#6B7280" text-anchor="middle">Admin Panel</text></svg>`;
+  const mainContent = `<g><rect x="150" y="15" width="435" height="370" fill="${contentBg}" rx="8" /><rect x="170" y="35" width="150" height="15" fill="#9CA3AF" rx="5" /><path d="M170 80 h395 M170 100 h395 M170 120 h250" stroke="#CBD5E1" stroke-width="8" stroke-linecap="round"/></g>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400"><rect width="100%" height="100%" fill="#F9FAFB"/><g>${sidebar}${mainContent}</g><text x="50%" y="95%" font-family="Arial" font-size="16" fill="#6B7280" text-anchor="middle">Admin Panel</text></svg>`;
   return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
 };
 
 const createPublicSvg = (theme) => {
-  let header, mainContent;
-  const bgColor = '#FFFFFF';
+  const headerColor = '#FFFFFF';
+  const contentBg = '#F3F4F6';
   const primaryColor = '#0891b2';
-  const textColor = '#374151';
+  const footerColor = '#1f2937';
 
+  let header, mainContent;
   switch (theme) {
     case 'playful':
-       header = `<rect x="5" y="15" width="90" height="370" fill="${primaryColor}" rx="8" transform="rotate(-2 50 185)" />`;
-       mainContent = `<rect x="110" y="15" width="475" height="370" fill="${bgColor}" rx="8" />`;
-       break;
+      header = `<g transform="rotate(-2 50 185)"><rect x="10" y="15" width="90" height="370" fill="${primaryColor}" rx="8" /><rect x="25" y="35" width="60" height="10" fill="white" rx="3"/><path d="M25 80 h60 M25 100 h60 M25 120 h60" stroke="white" stroke-width="4" stroke-linecap="round"/></g>`;
+      mainContent = `<rect x="115" y="15" width="470" height="370" fill="${headerColor}" rx="8" />`;
+      break;
     case 'single-page':
-      header = `<rect x="15" y="15" width="570" height="50" fill="${bgColor}" rx="8" />`;
-      mainContent = `<g><rect x="15" y="80" width="570" height="80" fill="#F3F4F6" rx="8" /><rect x="15" y="175" width="570" height="80" fill="#F3F4F6" rx="8" /><rect x="15" y="270" width="570" height="80" fill="#F3F4F6" rx="8" /></g>`;
+      header = `<rect x="15" y="15" width="570" height="40" fill="${headerColor}" rx="8" /><rect x="30" y="25" width="80" height="10" fill="${primaryColor}" rx="3" /><path d="M400 30 h150" stroke="#9CA3AF" stroke-width="6" stroke-linecap="round"/>`;
+      mainContent = `<g><rect x="15" y="70" width="570" height="315" fill="${contentBg}" rx="8" /><rect x="40" y="90" width="520" height="15" fill="#E5E7EB" rx="4" /><rect x="40" y="120" width="480" height="15" fill="#E5E7EB" rx="4" /><rect x="40" y="150" width="500" height="15" fill="#E5E7EB" rx="4" /></g>`;
       break;
     default:
-      header = `<rect x="15" y="15" width="570" height="50" fill="${bgColor}" rx="8" />`;
-      mainContent = `<rect x="15" y="80" width="570" height="305" fill="#F3F4F6" rx="8" />`;
+      header = `<rect x="15" y="15" width="570" height="50" fill="${headerColor}" rx="8" /><rect x="30" y="28" width="80" height="15" fill="${primaryColor}" rx="4" /><path d="M400 35 h30 M450 35 h30 M500 35 h30" stroke="#6B7280" stroke-width="5" stroke-linecap="round"/>`;
+      mainContent = `<rect x="15" y="80" width="570" height="255" fill="${contentBg}" rx="8" />`;
       break;
   }
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400"><rect width="100%" height="100%" fill="#E5E7EB"/><g>${header}${mainContent}</g><text x="50%" y="90%" font-family="Arial" font-size="20" fill="#6B7280" text-anchor="middle">Public Site</text></svg>`;
+  const footer = `<rect x="15" y="350" width="570" height="35" fill="${footerColor}" rx="8" />`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400"><rect width="100%" height="100%" fill="#E5E7EB"/><g>${header}${mainContent}${footer}</g><text x="50%" y="95%" font-family="Arial" font-size="16" fill="#6B7280" text-anchor="middle">Public Site</text></svg>`;
   return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
 };
 


### PR DESCRIPTION
This commit implements a complete redesign of the Appearance page and the public-facing themes based on user feedback.

Key Changes:

1.  **Appearance Page UI/UX:**
    - The "Color Schemes" section is renamed to "Color scheme presets".
    - The "Background Presets" section is now laid out side-by-side with the color presets for a more compact UI.
    - A new "Live Preview" component has been added, which dynamically updates to show the user the effect of their custom color and font choices before saving.
    - The SVG theme illustrations have been enhanced to be more detailed, providing a better wireframe-style preview of each layout.

2.  **Public Theme Redesign:**
    - The 'Compact' theme is now the 'Single Page' theme. When active, it transforms the public site into a one-page scrolling experience, fetching all content client-side.
    - The 'Playful' theme on the public site now uses a fixed, rotated sidebar menu, mirroring the admin panel's playful style.

3.  **Security & Bug Fixes:**
    - A critical security vulnerability was patched in the middleware to ensure all admin routes are protected and require authentication.
    - All JWT handling has been unified to use a single `JWT_SECRET` environment variable, fixing login and session errors.
    - Theme persistence issues have been resolved by disabling server-side caching for settings and ensuring the UI only updates after a successful save to the database.