### PR TITLE
fix: Correctly pass public theme from server to client

### DIFF
--- a/src/app/[lang]/layout.js
+++ b/src/app/[lang]/layout.js
@@ -27,7 +27,8 @@ async function getStyleSettings() {
         headerFont: 'Georgia, serif',
         bodyFont: 'Arial, sans-serif',
       },
-      appearance: settings?.appearance || 'default'
+      // Specifically return the publicAppearance for the public site
+      publicAppearance: settings?.publicAppearance || 'default'
     };
   } catch (error) {
     console.error("Failed to fetch style settings:", error);
@@ -41,7 +42,7 @@ async function getStyleSettings() {
         headerFont: 'Georgia, serif',
         bodyFont: 'Arial, sans-serif',
       },
-      appearance: 'default'
+      publicAppearance: 'default'
     };
   }
 }
@@ -85,7 +86,7 @@ export default async function RootLayout({ children, params }) {
       lang={params.lang}
       t={t}
       style={settings.style}
-      initialAppearance={settings.appearance}
+      initialAppearance={settings.publicAppearance}
       trips={trips}
       articles={articles}
     >


### PR DESCRIPTION
This commit fixes the final bug preventing theme persistence on the public site.

The `RootLayout` server component was fetching the correct settings from the database but was not passing the `publicAppearance` value down to the client components correctly.

The changes are:
- The `getStyleSettings` function in `src/app/[lang]/layout.js` now correctly returns the `publicAppearance` field.
- The `RootLayout` component now correctly passes this value as the `initialAppearance` prop to the `PublicLayoutClient`.

This ensures the client-side `AppearanceProvider` is initialized with the correct, persisted theme value from the server, eliminating the persistence bug.