### PR TITLE
feat: Add Polish and Serbian language support

### DIFF
--- a/src/components/admin/ArticleForm.js
+++ b/src/components/admin/ArticleForm.js
@@ -16,10 +16,12 @@ const languages = [
   { code: 'sk', name: 'Slovenčina' },
   { code: 'cs', name: 'Čeština' },
   { code: 'uk', name: 'Українська' },
+  { code: 'pl', name: 'Polski' },
+  { code: 'sr', name: 'Srpski' },
 ];
 
 // An object representing an empty set of multilingual fields.
-const emptyMultilingual = { en: '', de: '', hu: '', ru: '', sk: '', cs: '', uk: '' };
+const emptyMultilingual = { en: '', de: '', hu: '', ru: '', sk: '', cs: '', uk: '', pl: '', sr: '' };
 
 /**
  * A form for creating or updating an article.

--- a/src/components/admin/TripForm.js
+++ b/src/components/admin/TripForm.js
@@ -18,14 +18,16 @@ const languages = [
   { code: 'sk', name: 'Slovenčina' },
   { code: 'cs', name: 'Čeština' },
   { code: 'uk', name: 'Українська' },
+  { code: 'pl', name: 'Polski' },
+  { code: 'sr', name: 'Srpski' },
 ];
 
-const currencies = ['eur', 'gbp', 'huf', 'rub', 'czk', 'uah'];
-const emptyMultilingual = { en: '', de: '', hu: '', ru: '', sk: '', cs: '', uk: '' };
-const emptyPrices = { eur: 0, gbp: 0, huf: 0, rub: 0, czk: 0, uah: 0 };
+const currencies = ['eur', 'gbp', 'huf', 'rub', 'czk', 'uah', 'pln', 'rsd'];
+const emptyMultilingual = { en: '', de: '', hu: '', ru: '', sk: '', cs: '', uk: '', pl: '', sr: '' };
+const emptyPrices = { eur: 0, gbp: 0, huf: 0, rub: 0, czk: 0, uah: 0, pln: 0, rsd: 0 };
 
 // Approximate conversion rates relative to EUR for the price conversion feature.
-const conversionRates = { eur: 1, gbp: 0.85, huf: 400, rub: 90, czk: 25, uah: 42 };
+const conversionRates = { eur: 1, gbp: 0.85, huf: 400, rub: 90, czk: 25, uah: 42, pln: 4.3, rsd: 117 };
 
 // Rules for formatting prices to common marketing conventions (e.g., ending in .99).
 const priceFormatRules = {
@@ -35,6 +37,8 @@ const priceFormatRules = {
   rub: (p) => Math.floor(p / 100) * 100 + 99, // e.g., 1234 -> 1200 -> 1299
   czk: (p) => Math.floor(p) + 0.99,
   uah: (p) => Math.floor(p) + 0.99,
+  pln: (p) => Math.floor(p) + 0.99,
+  rsd: (p) => Math.round(p / 10) * 10, // e.g. 1234 -> 1230
 };
 
 /**

--- a/src/components/public/LanguageSelector.js
+++ b/src/components/public/LanguageSelector.js
@@ -18,6 +18,8 @@ const languages = [
   { code: 'sk', name: 'Slovakian', native: 'Slovenčina', flags: ['sk'] },
   { code: 'cs', name: 'Czech', native: 'Čeština', flags: ['cz'] },
   { code: 'uk', name: 'Ukrainian', native: 'Українська', flags: ['ua'] },
+  { code: 'pl', name: 'Polish', native: 'Polski', flags: ['pl'] },
+  { code: 'sr', name: 'Serbian', native: 'Srpski', flags: ['rs'] },
 ];
 
 /**

--- a/src/lib/getAdminTranslations.js
+++ b/src/lib/getAdminTranslations.js
@@ -13,6 +13,8 @@ const translations = {
   sk: () => import('@/translations/admin_sk.json').then((module) => module.default),
   cs: () => import('@/translations/admin_cs.json').then((module) => module.default),
   uk: () => import('@/translations/admin_uk.json').then((module) => module.default),
+  pl: () => import('@/translations/admin_pl.json').then((module) => module.default),
+  sr: () => import('@/translations/admin_sr.json').then((module) => module.default),
 };
 
 /**

--- a/src/lib/getTranslations.js
+++ b/src/lib/getTranslations.js
@@ -13,6 +13,8 @@ const translations = {
   sk: () => import('@/translations/sk.json').then((module) => module.default),
   cs: () => import('@/translations/cs.json').then((module) => module.default),
   uk: () => import('@/translations/uk.json').then((module) => module.default),
+  pl: () => import('@/translations/pl.json').then((module) => module.default),
+  sr: () => import('@/translations/sr.json').then((module) => module.default),
 };
 
 /**

--- a/src/translations/admin_cs.json
+++ b/src/translations/admin_cs.json
@@ -92,5 +92,17 @@
     "titleLabel": "Název článku",
     "contentLabel": "Obsah",
     "saveButton": "Uložit článek"
+  },
+  "appearance": {
+    "title": "Vzhled",
+    "globalThemes": "Globální motivy",
+    "currentPublicTheme": "Aktuální veřejný motiv:",
+    "currentAdminTheme": "Aktuální motiv administrace:",
+    "setThemeFor": "Nastavit motiv '{themeName}' pro:",
+    "publicSite": "Veřejná stránka",
+    "adminPanel": "Admin panel",
+    "both": "Obě",
+    "success": "Motiv '{themeName}' byl nastaven pro '{target}'.",
+    "error": "Chyba: Nepodařilo se uložit motiv. Zkontrolujte prosím logy serveru nebo konzoli prohlížeče."
   }
 }

--- a/src/translations/admin_de.json
+++ b/src/translations/admin_de.json
@@ -92,5 +92,17 @@
     "titleLabel": "Artikeltitel",
     "contentLabel": "Inhalt",
     "saveButton": "Artikel speichern"
+  },
+  "appearance": {
+    "title": "Erscheinungsbild",
+    "globalThemes": "Globale Themes",
+    "currentPublicTheme": "Aktuelles öffentliches Theme:",
+    "currentAdminTheme": "Aktuelles Admin-Theme:",
+    "setThemeFor": "Theme '{themeName}' festlegen für:",
+    "publicSite": "Öffentliche Seite",
+    "adminPanel": "Admin-Panel",
+    "both": "Beide",
+    "success": "Theme für '{target}' auf '{themeName}' gesetzt.",
+    "error": "Fehler: Theme konnte nicht gespeichert werden. Bitte Server-Logs oder Browser-Konsole prüfen."
   }
 }

--- a/src/translations/admin_en.json
+++ b/src/translations/admin_en.json
@@ -92,5 +92,17 @@
     "titleLabel": "Article Title",
     "contentLabel": "Content",
     "saveButton": "Save Article"
+  },
+  "appearance": {
+    "title": "Appearance",
+    "globalThemes": "Global Themes",
+    "currentPublicTheme": "Current Public Theme:",
+    "currentAdminTheme": "Current Admin Theme:",
+    "setThemeFor": "Set '{themeName}' as the theme for:",
+    "publicSite": "Public Site",
+    "adminPanel": "Admin Panel",
+    "both": "Both",
+    "success": "Theme set to '{themeName}' for '{target}' target.",
+    "error": "Error: Failed to save theme. Please check server logs or browser console."
   }
 }

--- a/src/translations/admin_hu.json
+++ b/src/translations/admin_hu.json
@@ -92,5 +92,17 @@
     "titleLabel": "Cikk címe",
     "contentLabel": "Tartalom",
     "saveButton": "Cikk mentése"
+  },
+  "appearance": {
+    "title": "Megjelenés",
+    "globalThemes": "Globális témák",
+    "currentPublicTheme": "Jelenlegi publikus téma:",
+    "currentAdminTheme": "Jelenlegi admin téma:",
+    "setThemeFor": "'{themeName}' téma beállítása a következőhöz:",
+    "publicSite": "Publikus oldal",
+    "adminPanel": "Admin panel",
+    "both": "Mindkettő",
+    "success": "A téma '{themeName}' lett beállítva a(z) '{target}' számára.",
+    "error": "Hiba: A téma mentése sikertelen. Kérjük, ellenőrizze a szerver naplókat vagy a böngésző konzolt."
   }
 }

--- a/src/translations/admin_pl.json
+++ b/src/translations/admin_pl.json
@@ -1,0 +1,108 @@
+{
+  "layout": {
+    "title": "Panel admina",
+    "dashboard": "Pulpit",
+    "trips": "Podróże",
+    "articles": "Artykuły",
+    "settings": "Ustawienia witryny",
+    "styling": "Wygląd",
+    "changePassword": "Zmień hasło",
+    "logout": "Wyloguj"
+  },
+  "dashboard": {
+    "title": "Pulpit",
+    "welcome": "Witaj w panelu administracyjnym.",
+    "manageTrips": "Zarządzaj podróżami",
+    "manageTripsDesc": "Twórz, edytuj i usuwaj nadchodzące podróże. Ustawiaj ceny i daty podróży.",
+    "manageArticles": "Zarządzaj artykułami",
+    "manageArticlesDesc": "Pisz i publikuj artykuły na blogu na stronie głównej.",
+    "updateSettings": "Aktualizuj ustawienia",
+    "updateSettingsDesc": "Zmieniaj globalne informacje o witrynie, takie jak dane kontaktowe.",
+    "updateStyling": "Dostosuj styl",
+    "updateStylingDesc": "Zmieniaj kolory, czcionki i układ witryny."
+  },
+  "trips": {
+    "manageTitle": "Zarządzaj podróżami",
+    "createButton": "Utwórz nową podróż",
+    "loading": "Ładowanie podróży...",
+    "noTrips": "Nie znaleziono podróży.",
+    "edit": "Edytuj",
+    "delete": "Usuń",
+    "deleteConfirm": "Czy na pewno chcesz usunąć tę podróż?",
+    "createTitle": "Utwórz nową podróż",
+    "editTitle": "Edytuj podróż"
+  },
+  "articles": {
+    "manageTitle": "Zarządzaj artykułami",
+    "createButton": "Napisz nowy artykuł",
+    "loading": "Ładowanie artykułów...",
+    "noArticles": "Nie znaleziono artykułów.",
+    "edit": "Edytuj",
+    "delete": "Usuń",
+    "deleteConfirm": "Czy na pewno chcesz usunąć ten artykuł?",
+    "createTitle": "Napisz nowy artykuł",
+    "editTitle": "Edytuj artykuł",
+    "publishedOn": "Opublikowano"
+  },
+  "settings": {
+    "title": "Ustawienia witryny",
+    "emailLabel": "Kontaktowy adres e-mail",
+    "phoneLabel": "Telefon kontaktowy",
+    "addressLabel": "Adres",
+    "saveButton": "Zapisz ustawienia",
+    "saving": "Zapisywanie...",
+    "success": "Ustawienia zapisane pomyślnie!",
+    "error": "Błąd"
+  },
+  "login": {
+    "title": "Logowanie administratora",
+    "usernameLabel": "Nazwa użytkownika",
+    "passwordLabel": "Hasło",
+    "button": "Zaloguj się",
+    "signingIn": "Logowanie...",
+    "forgotPassword": "Nie pamiętasz hasła?"
+  },
+  "changePassword": {
+    "title": "Zmień swoje hasło",
+    "titleLoggedIn": "Zmień hasło",
+    "intro": "Ze względów bezpieczeństwa musisz zmienić domyślne hasło.",
+    "newPasswordLabel": "Nowe hasło",
+    "confirmPasswordLabel": "Potwierdź nowe hasło",
+    "button": "Ustaw nowe hasło",
+    "success": "Hasło zaktualizowane pomyślnie!",
+    "errorMatch": "Hasła nie pasują do siebie.",
+    "errorLength": "Hasło musi mieć co najmniej 6 znaków."
+  },
+  "tripForm": {
+    "language": "Język",
+    "titleLabel": "Tytuł podróży",
+    "descriptionLabel": "Opis",
+    "pricingTitle": "Cennik",
+    "convertButton": "Konw.",
+    "convertTitle": "Konwertuj z",
+    "priceReminder": "Przypomnienie: W celach marketingowych najlepiej, aby ceny były zgodne z lokalną konwencją (np. kończyły się na .99).",
+    "priceSourceError": "Najpierw wprowadź prawidłową cenę w walucie źródłowej.",
+    "imageUrlLabel": "URL obrazu",
+    "startDateLabel": "Data rozpoczęcia",
+    "endDateLabel": "Data zakończenia",
+    "saveButton": "Zapisz podróż"
+  },
+  "articleForm": {
+    "language": "Język",
+    "titleLabel": "Tytuł artykułu",
+    "contentLabel": "Treść",
+    "saveButton": "Zapisz artykuł"
+  },
+  "appearance": {
+    "title": "Wygląd",
+    "globalThemes": "Globalne motywy",
+    "currentPublicTheme": "Aktualny motyw publiczny:",
+    "currentAdminTheme": "Aktualny motyw panelu admina:",
+    "setThemeFor": "Ustaw motyw '{themeName}' dla:",
+    "publicSite": "Strona publiczna",
+    "adminPanel": "Panel admina",
+    "both": "Oba",
+    "success": "Motyw '{themeName}' został ustawiony dla '{target}'.",
+    "error": "Błąd: Nie udało się zapisać motywu. Sprawdź logi serwera lub konsolę przeglądarki."
+  }
+}

--- a/src/translations/admin_ru.json
+++ b/src/translations/admin_ru.json
@@ -92,5 +92,17 @@
     "titleLabel": "Заголовок статьи",
     "contentLabel": "Содержание",
     "saveButton": "Сохранить статью"
+  },
+  "appearance": {
+    "title": "Внешний вид",
+    "globalThemes": "Глобальные темы",
+    "currentPublicTheme": "Текущая публичная тема:",
+    "currentAdminTheme": "Текущая тема админ-панели:",
+    "setThemeFor": "Установить тему '{themeName}' для:",
+    "publicSite": "Публичный сайт",
+    "adminPanel": "Админ-панель",
+    "both": "Оба",
+    "success": "Тема '{themeName}' установлена для '{target}'.",
+    "error": "Ошибка: Не удалось сохранить тему. Пожалуйста, проверьте логи сервера или консоль браузера."
   }
 }

--- a/src/translations/admin_sk.json
+++ b/src/translations/admin_sk.json
@@ -92,5 +92,17 @@
     "titleLabel": "Názov článku",
     "contentLabel": "Obsah",
     "saveButton": "Uložiť článok"
+  },
+  "appearance": {
+    "title": "Vzhľad",
+    "globalThemes": "Globálne témy",
+    "currentPublicTheme": "Aktuálna verejná téma:",
+    "currentAdminTheme": "Aktuálna téma admina:",
+    "setThemeFor": "Nastaviť tému '{themeName}' pre:",
+    "publicSite": "Verejná stránka",
+    "adminPanel": "Admin panel",
+    "both": "Obe",
+    "success": "Téma '{themeName}' bola nastavená pre '{target}'.",
+    "error": "Chyba: Nepodarilo sa uložiť tému. Skontrolujte prosím logy servera alebo konzolu prehliadača."
   }
 }

--- a/src/translations/admin_sr.json
+++ b/src/translations/admin_sr.json
@@ -1,0 +1,108 @@
+{
+  "layout": {
+    "title": "Admin panel",
+    "dashboard": "Kontrolna tabla",
+    "trips": "Putovanja",
+    "articles": "Članci",
+    "settings": "Podešavanja sajta",
+    "styling": "Izgled",
+    "changePassword": "Promeni lozinku",
+    "logout": "Odjavi se"
+  },
+  "dashboard": {
+    "title": "Kontrolna tabla",
+    "welcome": "Dobrodošli u admin panel.",
+    "manageTrips": "Upravljajte putovanjima",
+    "manageTripsDesc": "Kreirajte, uređujte i brišite nadolazeća putovanja. Podesite cene i datume putovanja.",
+    "manageArticles": "Upravljajte člancima",
+    "manageArticlesDesc": "Pišite i objavljujte članke za blog na glavnoj stranici.",
+    "updateSettings": "Ažurirajte podešavanja",
+    "updateSettingsDesc": "Promenite informacije o celom sajtu, kao što su kontakt podaci.",
+    "updateStyling": "Prilagodite stil",
+    "updateStylingDesc": "Promenite boje, fontove i izgled sajta."
+  },
+  "trips": {
+    "manageTitle": "Upravljajte putovanjima",
+    "createButton": "Kreiraj novo putovanje",
+    "loading": "Učitavanje putovanja...",
+    "noTrips": "Nema pronađenih putovanja.",
+    "edit": "Uredi",
+    "delete": "Obriši",
+    "deleteConfirm": "Da li ste sigurni da želite da obrišete ovo putovanje?",
+    "createTitle": "Kreiraj novo putovanje",
+    "editTitle": "Uredi putovanje"
+  },
+  "articles": {
+    "manageTitle": "Upravljajte člancima",
+    "createButton": "Napišite novi članak",
+    "loading": "Učitavanje članaka...",
+    "noArticles": "Nema pronađenih članaka.",
+    "edit": "Uredi",
+    "delete": "Obriši",
+    "deleteConfirm": "Da li ste sigurni da želite da obrišete ovaj članak?",
+    "createTitle": "Napišite novi članak",
+    "editTitle": "Uredi članak",
+    "publishedOn": "Objavljeno"
+  },
+  "settings": {
+    "title": "Podešavanja sajta",
+    "emailLabel": "Kontakt email",
+    "phoneLabel": "Kontakt telefon",
+    "addressLabel": "Adresa",
+    "saveButton": "Sačuvaj podešavanja",
+    "saving": "Čuvanje...",
+    "success": "Podešavanja uspešno sačuvana!",
+    "error": "Greška"
+  },
+  "login": {
+    "title": "Admin prijava",
+    "usernameLabel": "Korisničko ime",
+    "passwordLabel": "Lozinka",
+    "button": "Prijavi se",
+    "signingIn": "Prijavljivanje...",
+    "forgotPassword": "Zaboravili ste lozinku?"
+  },
+  "changePassword": {
+    "title": "Promenite Vašu lozinku",
+    "titleLoggedIn": "Promeni lozinku",
+    "intro": "Kao mera bezbednosti, morate promeniti podrazumevanu lozinku.",
+    "newPasswordLabel": "Nova lozinka",
+    "confirmPasswordLabel": "Potvrdite novu lozinku",
+    "button": "Postavi novu lozinku",
+    "success": "Lozinka uspešno ažurirana!",
+    "errorMatch": "Lozinke se ne podudaraju.",
+    "errorLength": "Lozinka mora imati najmanje 6 karaktera."
+  },
+  "tripForm": {
+    "language": "Jezik",
+    "titleLabel": "Naslov putovanja",
+    "descriptionLabel": "Opis",
+    "pricingTitle": "Cene",
+    "convertButton": "Konv.",
+    "convertTitle": "Konvertuj iz",
+    "priceReminder": "Podsetnik: Za marketing je najbolje da cene prate lokalnu konvenciju (npr. završavaju se na .99).",
+    "priceSourceError": "Prvo unesite važeću cenu u izvornoj valuti.",
+    "imageUrlLabel": "URL slike",
+    "startDateLabel": "Datum početka",
+    "endDateLabel": "Datum završetka",
+    "saveButton": "Sačuvaj putovanje"
+  },
+  "articleForm": {
+    "language": "Jezik",
+    "titleLabel": "Naslov članka",
+    "contentLabel": "Sadržaj",
+    "saveButton": "Sačuvaj članak"
+  },
+  "appearance": {
+    "title": "Izgled",
+    "globalThemes": "Globalne teme",
+    "currentPublicTheme": "Trenutna javna tema:",
+    "currentAdminTheme": "Trenutna admin tema:",
+    "setThemeFor": "Postavi temu '{themeName}' za:",
+    "publicSite": "Javni sajt",
+    "adminPanel": "Admin panel",
+    "both": "Oba",
+    "success": "Tema '{themeName}' je postavljena za '{target}'.",
+    "error": "Greška: Čuvanje teme nije uspelo. Proverite logove servera ili konzolu pregledača."
+  }
+}

--- a/src/translations/admin_uk.json
+++ b/src/translations/admin_uk.json
@@ -92,5 +92,17 @@
     "titleLabel": "Заголовок статті",
     "contentLabel": "Зміст",
     "saveButton": "Зберегти статтю"
+  },
+  "appearance": {
+    "title": "Зовнішній вигляд",
+    "globalThemes": "Глобальні теми",
+    "currentPublicTheme": "Поточна публічна тема:",
+    "currentAdminTheme": "Поточна тема адмін-панелі:",
+    "setThemeFor": "Встановити тему '{themeName}' для:",
+    "publicSite": "Публічний сайт",
+    "adminPanel": "Адмін-панель",
+    "both": "Обидва",
+    "success": "Тему '{themeName}' встановлено для '{target}'.",
+    "error": "Помилка: Не вдалося зберегти тему. Будь ласка, перевірте логи сервера або консоль браузера."
   }
 }

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -1,0 +1,77 @@
+{
+  "header": {
+    "home": "Strona główna",
+    "pricing": "Cennik",
+    "trips": "Nadchodzące podróże",
+    "articles": "Artykuły",
+    "about": "O nas",
+    "contact": "Kontakt"
+  },
+  "footer": {
+    "slogan": "Twoja podróż zaczyna się tutaj.",
+    "rights": "Wszelkie prawa zastrzeżone."
+  },
+  "homePage": {
+    "heroTitle": "Twoja następna podróż, koleją",
+    "heroSubtitle": "Odkryj świat z innej perspektywy. Czekają na Ciebie niezapomniane krajobrazy, komfortowe podróże i ponadczasowe wspomnienia.",
+    "heroButton": "Przeglądaj nadchodzące podróże",
+    "journalTitle": "Z naszego dziennika podróży",
+    "readMore": "Czytaj więcej",
+    "noArticles": "Brak artykułów do wyświetlenia. Utwórz jeden w panelu administracyjnym!"
+  },
+  "pricingPage": {
+    "title": "Nasza filozofia cenowa",
+    "body1": "W Train.Travel wierzymy w przejrzyste i proste ceny. Koszt każdej podróży jest kompleksowy i obejmuje podróż, zakwaterowanie na pokładzie oraz wyselekcjonowane atrakcje. Staramy się zapewniać wyjątkową wartość, łącząc luksus i przygodę w każdym pakiecie.",
+    "standardClass": "Klasa standardowa",
+    "standardDesc": "Wygodne siedzenia i panoramiczne okna, aby cieszyć się widokiem.",
+    "firstClass": "Pierwsza klasa",
+    "firstDesc": "Dodatkowa przestrzeń na nogi, bezpłatne napoje i priorytetowa obsługa.",
+    "sleeperCabin": "Kabina sypialna",
+    "sleeperDesc": "Prywatne kabiny na nocne podróże, zapewniające spokojny sen.",
+    "body2": "Ceny różnią się w zależności od miejsca docelowego, czasu trwania i klasy podróży. Aby uzyskać szczegółowe ceny naszych wyselekcjonowanych podróży, odwiedź naszą stronę Nadchodzące podróże.",
+    "button": "Zobacz nadchodzące podróże i ceny"
+  },
+  "tripsPage": {
+    "title": "Nadchodzące podróże",
+    "subtitle": "Wyrusz w swoją następną wielką przygodę.",
+    "viewDetails": "Zobacz szczegóły",
+    "noTrips": "W tej chwili nie ma żadnych nadchodzących podróży. Prosimy sprawdzić ponownie wkrótce!"
+  },
+  "articlesPage": {
+    "title": "Dziennik podróży",
+    "subtitle": "Historie i spostrzeżenia z naszych podróży."
+  },
+  "aboutPage": {
+    "title": "O Train.Travel",
+    "subtitle": "Łączymy ludzi z miejscami, jedna malownicza trasa na raz.",
+    "body1": "Train.Travel powstało w oparciu o proste założenie: podróż jest równie ważna jak cel. W świecie, który pędzi z punktu A do punktu B, oferujemy szansę na zwolnienie tempa, zobaczenie piękna krajobrazu i doświadczenie podróży w bardziej znaczący i zrównoważony sposób.",
+    "body2": "Nasz zespół składa się z pasjonatów podróży, ekspertów logistyki i entuzjastów kolei, którzy niestrudzenie pracują nad tworzeniem unikalnych podróży pociągiem po całym świecie. Od majestatycznych gór Szwajcarii po rozległe krajobrazy Kolei Transsyberyjskiej, wybieramy trasy, które oferują zapierające dech w piersiach widoki i niezapomniane wrażenia.",
+    "missionTitle": "Nasza misja",
+    "missionText": "Zapewnianie komfortowych, malowniczych i przyjaznych dla środowiska podróży, które tworzą trwałe wspomnienia i promują głębsze docenienie otaczającego nas świata.",
+    "body3": "Współpracujemy z najlepszymi operatorami kolejowymi na świecie, aby zapewnić najwyższe standardy komfortu, bezpieczeństwa i obsługi. Niezależnie od tego, czy jesteś samotnym poszukiwaczem przygód, parą szukającą romantycznego wypadu, czy rodziną szukającą wyjątkowych wakacji, mamy podróż idealną для Ciebie.",
+    "body4": "Dziękujemy za zainteresowanie Train.Travel. Z niecierpliwością czekamy na powitanie Cię na pokładzie."
+  },
+  "contactPage": {
+    "title": "Skontaktuj się z nami",
+    "subtitle": "Chętnie Cię wysłuchamy. Skontaktuj się z nami w razie jakichkolwiek pytań.",
+    "formTitle": "Wyślij nam wiadomość",
+    "nameLabel": "Imię i nazwisko",
+    "emailLabel": "Adres e-mail",
+    "messageLabel": "Wiadomość",
+    "submitButton": "Wyślij",
+    "infoTitle": "Nasze informacje",
+    "emailHeader": "E-mail",
+    "phoneHeader": "Telefon",
+    "addressHeader": "Adres"
+  },
+  "tripDetailPage": {
+    "bookingTitle": "Zarezerwuj swoją podróż",
+    "inquireButton": "Zapytaj teraz",
+    "from": "Od",
+    "to": "Do"
+  },
+  "articleDetailPage": {
+    "publishedOn": "Opublikowano",
+    "by": "przez"
+  }
+}

--- a/src/translations/sr.json
+++ b/src/translations/sr.json
@@ -1,0 +1,77 @@
+{
+  "header": {
+    "home": "Početna",
+    "pricing": "Cene",
+    "trips": "Nadolazeća putovanja",
+    "articles": "Članci",
+    "about": "O nama",
+    "contact": "Kontakt"
+  },
+  "footer": {
+    "slogan": "Vaše putovanje počinje ovde.",
+    "rights": "Sva prava zadržana."
+  },
+  "homePage": {
+    "heroTitle": "Vaše sledeće putovanje, vozom",
+    "heroSubtitle": "Otkrijte svet iz drugačije perspektive. Očekuju vas nezaboravni pejzaži, udobna putovanja i vanvremenske uspomene.",
+    "heroButton": "Istražite nadolazeća putovanja",
+    "journalTitle": "Iz našeg dnevnika putovanja",
+    "readMore": "Pročitajte više",
+    "noArticles": "Još uvek nema članaka za prikaz. Kreirajte jedan u admin panelu!"
+  },
+  "pricingPage": {
+    "title": "Naša filozofija cena",
+    "body1": "U Train.Travel verujemo u transparentne i jednostavne cene. Troškovi svakog putovanja su sveobuhvatni, pokrivajući vaše putovanje, smeštaj u vozu i odabrana iskustva. Trudimo se da pružimo izuzetnu vrednost, kombinujući luksuz i avanturu u svakom paketu.",
+    "standardClass": "Standardna klasa",
+    "standardDesc": "Udobna sedišta i panoramski prozori za uživanje u pogledu.",
+    "firstClass": "Prva klasa",
+    "firstDesc": "Dodatni prostor za noge, besplatna osveženja i prioritetna usluga.",
+    "sleeperCabin": "Spavaća kabina",
+    "sleeperDesc": "Privatne kabine za noćna putovanja, obezbeđujući miran san.",
+    "body2": "Cene variraju u zavisnosti od destinacije, trajanja i klase putovanja. Za detaljne cene naših odabranih putovanja, posetite našu stranicu Nadolazeća putovanja.",
+    "button": "Pogledajte nadolazeća putovanja i cene"
+  },
+  "tripsPage": {
+    "title": "Nadolazeća putovanja",
+    "subtitle": "Krenite u svoju sledeću veliku avanturu.",
+    "viewDetails": "Pogledajte detalje",
+    "noTrips": "Trenutno nema nadolazećih putovanja. Molimo proverite ponovo uskoro!"
+  },
+  "articlesPage": {
+    "title": "Dnevnik putovanja",
+    "subtitle": "Priče i uvidi sa naših putovanja."
+  },
+  "aboutPage": {
+    "title": "O Train.Travel",
+    "subtitle": "Povezujemo ljude sa mestima, jedna slikovita ruta u isto vreme.",
+    "body1": "Train.Travel je osnovan na jednostavnoj premisi: putovanje je jednako važno kao i destinacija. U svetu koji žuri od tačke A do tačke B, nudimo priliku da usporite, da vidite lepotu pejzaža kako se odvija i da doživite putovanje na značajniji i održiviji način.",
+    "body2": "Naš tim se sastoji od strastvenih putnika, stručnjaka za logistiku i ljubitelja železnice koji neumorno rade na kreiranju jedinstvenih putovanja vozom širom sveta. Od veličanstvenih planina Švajcarske do prostranih pejzaža Transsibirske železnice, biramo rute koje nude predivne poglede i nezaboravna iskustva.",
+    "missionTitle": "Naša misija",
+    "missionText": "Pružanje udobnih, slikovitih i ekološki prihvatljivih putničkih iskustava koja stvaraju trajne uspomene i podstiču dublje poštovanje prema svetu oko nas.",
+    "body3": "Sarađujemo sa najboljim svetskim železničkim operaterima kako bismo osigurali najviše standarde udobnosti, bezbednosti i usluge. Bilo da ste solo avanturista, par koji traži romantični odmor ili porodica koja traži jedinstven odmor, imamo putovanje koje je savršeno za vas.",
+    "body4": "Hvala vam što ste razmotrili Train.Travel. Radujemo se što ćemo vas ugostiti."
+  },
+  "contactPage": {
+    "title": "Kontaktirajte nas",
+    "subtitle": "Voleli bismo da čujemo vaše mišljenje. Obratite nam se sa bilo kakvim pitanjima.",
+    "formTitle": "Pošaljite nam poruku",
+    "nameLabel": "Puno ime i prezime",
+    "emailLabel": "Email adresa",
+    "messageLabel": "Poruka",
+    "submitButton": "Pošalji",
+    "infoTitle": "Naše informacije",
+    "emailHeader": "Email",
+    "phoneHeader": "Telefon",
+    "addressHeader": "Adresa"
+  },
+  "tripDetailPage": {
+    "bookingTitle": "Rezervišite svoje putovanje",
+    "inquireButton": "Raspitajte se sada",
+    "from": "Od",
+    "to": "Do"
+  },
+  "articleDetailPage": {
+    "publishedOn": "Objavljeno",
+    "by": "od"
+  }
+}


### PR DESCRIPTION
This commit introduces full internationalization support for Polish (pl) and Serbian (sr).

- Adds Polish and Serbian to all language selection components in the public and admin areas.
- Adds currency support for Polish Złoty (PLN) and Serbian Dinar (RSD) in the trip management form, including conversion rates and formatting rules.
- Creates new public and admin translation files (`pl.json`, `admin_pl.json`, `sr.json`, `admin_sr.json`) and populates them with translated text.
- Updates the dynamic translation loaders to include the new languages.
- Refactors the Appearance/Styling editor in the admin panel to be fully internationalized and adds the corresponding translations to all admin language files.