### PR TITLE
feat(theme): Enhance playful theme animations and fix layout

### DIFF
--- a/src/components/admin/AdminLayoutClient.js
+++ b/src/components/admin/AdminLayoutClient.js
@@ -73,7 +73,7 @@ export default function AdminLayoutClient({ children }) {
   const asideClasses = {
     default: "w-64 bg-gray-800 text-white flex flex-col",
     compact: "hidden", // Sidebar is hidden in compact view
-    playful: "w-72 bg-indigo-800 text-white flex flex-col transform -rotate-3 -ml-4",
+    playful: "w-72 bg-indigo-800 text-white flex flex-col transform -rotate-6 -ml-20 origin-top-left transition-all duration-300 ease-in-out group-hover:rotate-0 group-hover:ml-0",
   };
 
   // Helper function to determine the CSS classes for a navigation link.
@@ -155,7 +155,7 @@ export default function AdminLayoutClient({ children }) {
   // Render the appropriate layout based on the appearance setting.
   return (
     <div className={layoutClasses[appearance]}>
-      {appearance !== 'compact' && <Sidebar />}
+      {appearance !== 'compact' && <div className="group"><Sidebar /></div>}
       {appearance === 'compact' && <Topbar />}
       {mainContent}
     </div>

--- a/src/components/public/LanguageSelector.js
+++ b/src/components/public/LanguageSelector.js
@@ -91,7 +91,7 @@ export default function LanguageSelector() {
       {/* The button that shows the current language and toggles the dropdown */}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-between w-64 px-3 py-2 text-gray-700 bg-white border rounded-md shadow-sm"
+        className="flex items-center justify-between w-full px-3 py-2 text-gray-700 bg-white border rounded-md shadow-sm"
       >
         <div className="flex items-center gap-2 overflow-hidden">
           <FlagGroup codes={currentLang.flags} />

--- a/src/components/public/PlayfulHeader.js
+++ b/src/components/public/PlayfulHeader.js
@@ -30,10 +30,12 @@ export default function PlayfulHeader({ lang, t }) {
 
   return (
     // The `aside` element is used for the sidebar, which is fixed and rotated.
-    <aside className="bg-indigo-800 text-white w-64 h-full fixed top-0 left-0 overflow-y-auto z-50 p-6 flex flex-col transform -rotate-2 -ml-2">
-      <div className="flex-shrink-0 mb-8">
-        <TrainLogo lang={lang} />
-      </div>
+    // We wrap it in a div with the `group` class to control hover effects on children.
+    <div className="group fixed top-0 left-0 h-full z-50">
+      <aside className="bg-indigo-800 text-white w-64 h-full p-6 flex flex-col transform -rotate-6 -ml-16 origin-top-left transition-all duration-300 ease-in-out group-hover:rotate-0 group-hover:ml-0">
+        <div className="flex-shrink-0 mb-8">
+          <TrainLogo lang={lang} />
+        </div>
 
       <nav className="flex-grow space-y-3">
         {navLinks.map(link => (
@@ -43,7 +45,7 @@ export default function PlayfulHeader({ lang, t }) {
         ))}
       </nav>
 
-      <div className="flex-shrink-0 mt-8">
+      <div className="flex-shrink-0 mt-8 w-full">
         <LanguageSelector />
       </div>
     </aside>


### PR DESCRIPTION
This commit enhances the 'playful' theme based on user feedback.

- Increases the initial rotation of the sidebar for a more pronounced effect in both the public and admin layouts.
- Adds a `group-hover` effect to the sidebars, which animates them back to an upright position (rotate-0) for improved readability and interaction.
- Removes the fixed width from the public LanguageSelector component, allowing it to fit correctly within the rotated sidebar without overflowing.