### PR TITLE
fix: Correct syntax error in PlayfulHeader component

### DIFF
--- a/src/components/public/PlayfulHeader.js
+++ b/src/components/public/PlayfulHeader.js
@@ -49,5 +49,6 @@ export default function PlayfulHeader({ lang, t }) {
         <LanguageSelector />
       </div>
     </aside>
+    </div>
   );
 }


### PR DESCRIPTION
This commit fixes a build error caused by a missing closing `</div>` tag in the `PlayfulHeader.js` component. The missing tag was introduced during a previous refactor to add a hover effect.