### PR TITLE
feat(theme): Add animations and fix layout for playful theme

### DIFF
--- a/src/app/[lang]/page.js
+++ b/src/app/[lang]/page.js
@@ -4,6 +4,7 @@
  */
 import Link from 'next/link';
 import { getTranslations } from '@/lib/getTranslations';
+import AnimatedSection from '@/components/public/AnimatedSection';
 
 /**
  * Fetches the 3 most recent articles from the public API.
@@ -36,43 +37,47 @@ export default async function HomePage({ params: { lang } }) {
   return (
     <div className="space-y-16">
       {/* Hero Section */}
-      <section className="text-center bg-white p-12 rounded-lg shadow-lg">
-        <h1 className="text-5xl font-extrabold text-gray-900 font-header">{t.homePage.heroTitle}</h1>
-        <p className="mt-4 text-xl text-text/80 max-w-2xl mx-auto">{t.homePage.heroSubtitle}</p>
-        <div className="mt-8">
-          <Link href={`/${lang}/trips`} className="px-8 py-4 text-lg font-semibold text-white bg-primary rounded-lg hover:opacity-90 transition-opacity">
-            {t.homePage.heroButton}
-          </Link>
-        </div>
-      </section>
+      <AnimatedSection>
+        <section className="text-center bg-white p-12 rounded-lg shadow-lg">
+          <h1 className="text-5xl font-extrabold text-gray-900 font-header">{t.homePage.heroTitle}</h1>
+          <p className="mt-4 text-xl text-text/80 max-w-2xl mx-auto">{t.homePage.heroSubtitle}</p>
+          <div className="mt-8">
+            <Link href={`/${lang}/trips`} className="px-8 py-4 text-lg font-semibold text-white bg-primary rounded-lg hover:opacity-90 transition-opacity">
+              {t.homePage.heroButton}
+            </Link>
+          </div>
+        </section>
+      </AnimatedSection>
 
       {/* Recent Articles Section */}
-      <section>
-        <h2 className="text-3xl font-bold text-center mb-8 font-header">{t.homePage.journalTitle}</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {recentArticles.map(article => (
-            <div key={article._id} className="bg-white rounded-lg shadow-md overflow-hidden transform hover:-translate-y-2 transition-transform duration-300 flex flex-col group">
-              <div className="p-6 flex-grow flex flex-col">
-                <h3 className="text-xl font-semibold my-2 font-header">{article.title[lang] || article.title.en}</h3>
-                {/* The article content is rendered using dangerouslySetInnerHTML because it comes from a rich text editor. */}
-                <div
-                  className="text-text/80 line-clamp-4 flex-grow prose"
-                  dangerouslySetInnerHTML={{ __html: article.content[lang] || article.content.en }}
-                />
-                <div className="mt-4">
-                  <Link href={`/${lang}/articles/${article._id}`} className="text-primary hover:underline font-semibold">
-                    {t.homePage.readMore} &rarr;
-                  </Link>
+      <AnimatedSection>
+        <section>
+          <h2 className="text-3xl font-bold text-center mb-8 font-header">{t.homePage.journalTitle}</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {recentArticles.map(article => (
+              <div key={article._id} className="bg-white rounded-lg shadow-md overflow-hidden transform hover:-translate-y-2 transition-transform duration-300 flex flex-col group">
+                <div className="p-6 flex-grow flex flex-col">
+                  <h3 className="text-xl font-semibold my-2 font-header">{article.title[lang] || article.title.en}</h3>
+                  {/* The article content is rendered using dangerouslySetInnerHTML because it comes from a rich text editor. */}
+                  <div
+                    className="text-text/80 line-clamp-4 flex-grow prose"
+                    dangerouslySetInnerHTML={{ __html: article.content[lang] || article.content.en }}
+                  />
+                  <div className="mt-4">
+                    <Link href={`/${lang}/articles/${article._id}`} className="text-primary hover:underline font-semibold">
+                      {t.homePage.readMore} &rarr;
+                    </Link>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
-          {/* Display a message if there are no articles to show. */}
-          {recentArticles.length === 0 && (
-            <p className="text-center text-text/70 col-span-3">{t.homePage.noArticles}</p>
-          )}
-        </div>
-      </section>
+            ))}
+            {/* Display a message if there are no articles to show. */}
+            {recentArticles.length === 0 && (
+              <p className="text-center text-text/70 col-span-3">{t.homePage.noArticles}</p>
+            )}
+          </div>
+        </section>
+      </AnimatedSection>
     </div>
   );
 }

--- a/src/components/admin/AdminLayoutClient.js
+++ b/src/components/admin/AdminLayoutClient.js
@@ -119,12 +119,21 @@ export default function AdminLayoutClient({ children }) {
   /**
    * The sidebar component, used in 'default' and 'playful' themes.
    */
-  const Sidebar = () => (
+  const Sidebar = () => {
+    const playfulLinkClasses = "block px-4 py-2 rounded hover:bg-indigo-700 transition-all duration-200 hover:translate-x-2";
+    const defaultLinkClasses = (href) => {
+        const base = "block px-4 py-2 rounded";
+        const hover = "hover:bg-gray-700";
+        const active = pathname.startsWith(href) ? "bg-primary" : "";
+        return `${base} ${hover} ${active}`;
+    };
+
+    return (
     <aside className={asideClasses[appearance]}>
       <div className={`p-4 text-xl font-bold border-b ${appearance === 'playful' ? 'border-indigo-700' : 'border-gray-700'}`}>{t.layout.title}</div>
       <nav className="flex-grow p-4 space-y-2">
         {navLinks.map(link => (
-          <Link key={link.href} href={link.href} className={navLinkClasses(link.href)}>{link.label}</Link>
+          <Link key={link.href} href={link.href} className={appearance === 'playful' ? playfulLinkClasses : defaultLinkClasses(link.href)}>{link.label}</Link>
         ))}
       </nav>
       <div className={`p-4 border-t ${appearance === 'playful' ? 'border-indigo-700' : 'border-gray-700'}`}>

--- a/src/components/public/AnimatedSection.js
+++ b/src/components/public/AnimatedSection.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview This file defines the AnimatedSection component, a wrapper that
+ * animates its children as they scroll into view, but only if the 'playful'
+ * theme is active.
+ */
+'use client';
+
+import { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { useAppearance } from '@/components/admin/AppearanceSettings';
+
+/**
+ * A reusable component that wraps its children in a motion.div to animate them
+ * as they scroll into view, but only for the 'playful' theme.
+ * @param {{children: React.ReactNode}} props - The component props.
+ * @returns {JSX.Element} The animated section or a simple div.
+ */
+export default function AnimatedSection({ children }) {
+  const { publicAppearance } = useAppearance();
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true, margin: "-100px 0px" });
+
+  if (publicAppearance !== 'playful') {
+    return <div>{children}</div>;
+  }
+
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: 50 }}
+      animate={{ opacity: isInView ? 1 : 0, y: isInView ? 0 : 50 }}
+      transition={{ duration: 0.8, ease: "easeOut" }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/public/LanguageSelector.js
+++ b/src/components/public/LanguageSelector.js
@@ -104,7 +104,7 @@ export default function LanguageSelector() {
 
       {/* The dropdown menu with the list of available languages */}
       {isOpen && (
-        <div className="absolute right-0 w-full mt-2 origin-top-right bg-white rounded-md shadow-lg z-50">
+        <div className="absolute left-0 w-full mt-2 origin-top-left bg-white rounded-md shadow-lg z-50">
           <div className="py-1">
             {languages.map(lang => (
               <Link

--- a/src/components/public/PlayfulHeader.js
+++ b/src/components/public/PlayfulHeader.js
@@ -39,7 +39,7 @@ export default function PlayfulHeader({ lang, t }) {
 
       <nav className="flex-grow space-y-3">
         {navLinks.map(link => (
-          <Link key={link.href} href={link.href} className="block text-lg py-2 px-4 rounded-lg hover:bg-indigo-700 transition-colors duration-200">
+          <Link key={link.href} href={link.href} className="block text-lg py-2 px-4 rounded-lg hover:bg-indigo-700 transition-all duration-200 hover:translate-x-2">
             {link.label}
           </Link>
         ))}


### PR DESCRIPTION
This commit implements several enhancements to the 'playful' theme based on user feedback.

- Fixes the language selector dropdown by making it open to the left, ensuring it is fully visible within the rotated sidebar.
- Adds subtle `hover:translate-x-2` animations to navigation links in both public and admin playful sidebars.
- Creates a new `AnimatedSection` component that applies on-scroll animations only when the playful theme is active.
- Wraps sections on the homepage with `AnimatedSection` to add more dynamism.