### PR TITLE
feat(theme): Enhance playful theme and fix language selector

### DIFF
--- a/src/app/[lang]/page.js
+++ b/src/app/[lang]/page.js
@@ -4,6 +4,7 @@
  */
 import Link from 'next/link';
 import { getTranslations } from '@/lib/getTranslations';
+import AnimatedSection from '@/components/public/AnimatedSection';
 
 /**
  * Fetches the 3 most recent articles from the public API.
@@ -36,43 +37,47 @@ export default async function HomePage({ params: { lang } }) {
   return (
     <div className="space-y-16">
       {/* Hero Section */}
-      <section className="text-center bg-white p-12 rounded-lg shadow-lg">
-        <h1 className="text-5xl font-extrabold text-gray-900 font-header">{t.homePage.heroTitle}</h1>
-        <p className="mt-4 text-xl text-text/80 max-w-2xl mx-auto">{t.homePage.heroSubtitle}</p>
-        <div className="mt-8">
-          <Link href={`/${lang}/trips`} className="px-8 py-4 text-lg font-semibold text-white bg-primary rounded-lg hover:opacity-90 transition-opacity">
-            {t.homePage.heroButton}
-          </Link>
-        </div>
-      </section>
+      <AnimatedSection>
+        <section className="text-center bg-white p-12 rounded-lg shadow-lg">
+          <h1 className="text-5xl font-extrabold text-gray-900 font-header">{t.homePage.heroTitle}</h1>
+          <p className="mt-4 text-xl text-text/80 max-w-2xl mx-auto">{t.homePage.heroSubtitle}</p>
+          <div className="mt-8">
+            <Link href={`/${lang}/trips`} className="playful-button inline-block px-8 py-4 text-lg font-semibold text-white bg-primary rounded-lg hover:opacity-90 transition-opacity">
+              {t.homePage.heroButton}
+            </Link>
+          </div>
+        </section>
+      </AnimatedSection>
 
       {/* Recent Articles Section */}
-      <section>
-        <h2 className="text-3xl font-bold text-center mb-8 font-header">{t.homePage.journalTitle}</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {recentArticles.map(article => (
-            <div key={article._id} className="bg-white rounded-lg shadow-md overflow-hidden transform hover:-translate-y-2 transition-transform duration-300 flex flex-col group">
-              <div className="p-6 flex-grow flex flex-col">
-                <h3 className="text-xl font-semibold my-2 font-header">{article.title[lang] || article.title.en}</h3>
-                {/* The article content is rendered using dangerouslySetInnerHTML because it comes from a rich text editor. */}
-                <div
-                  className="text-text/80 line-clamp-4 flex-grow prose"
-                  dangerouslySetInnerHTML={{ __html: article.content[lang] || article.content.en }}
-                />
-                <div className="mt-4">
-                  <Link href={`/${lang}/articles/${article._id}`} className="text-primary hover:underline font-semibold">
-                    {t.homePage.readMore} &rarr;
-                  </Link>
+      <AnimatedSection>
+        <section>
+          <h2 className="text-3xl font-bold text-center mb-8 font-header">{t.homePage.journalTitle}</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {recentArticles.map(article => (
+              <div key={article._id} className="playful-card bg-white rounded-lg shadow-md overflow-hidden transform hover:-translate-y-2 transition-transform duration-300 flex flex-col group">
+                <div className="p-6 flex-grow flex flex-col">
+                  <h3 className="text-xl font-semibold my-2 font-header">{article.title[lang] || article.title.en}</h3>
+                  {/* The article content is rendered using dangerouslySetInnerHTML because it comes from a rich text editor. */}
+                  <div
+                    className="text-text/80 line-clamp-4 flex-grow prose"
+                    dangerouslySetInnerHTML={{ __html: article.content[lang] || article.content.en }}
+                  />
+                  <div className="mt-4">
+                    <Link href={`/${lang}/articles/${article._id}`} className="text-primary hover:underline font-semibold">
+                      {t.homePage.readMore} &rarr;
+                    </Link>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
-          {/* Display a message if there are no articles to show. */}
-          {recentArticles.length === 0 && (
-            <p className="text-center text-text/70 col-span-3">{t.homePage.noArticles}</p>
-          )}
-        </div>
-      </section>
+            ))}
+            {/* Display a message if there are no articles to show. */}
+            {recentArticles.length === 0 && (
+              <p className="text-center text-text/70 col-span-3">{t.homePage.noArticles}</p>
+            )}
+          </div>
+        </section>
+      </AnimatedSection>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,3 +73,16 @@
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
   border-radius: 8px;
 }
+
+.theme-playful .playful-card {
+  transition: all 0.3s ease-out;
+}
+
+.theme-playful .playful-card:hover {
+  transform: translateY(-8px) scale(1.02);
+  box-shadow: 0 10px 20px rgba(0,0,0,0.15);
+}
+
+.theme-playful .playful-button:hover {
+  transform: scale(1.1) rotate(-2deg);
+}

--- a/src/components/public/LanguageSelector.js
+++ b/src/components/public/LanguageSelector.js
@@ -6,6 +6,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 
@@ -24,8 +25,6 @@ const languages = [
 
 /**
  * A small component to display a single flag image.
- * It uses a special URL for the UN flag.
- * @param {{code: string}} props - The component props.
  */
 const Flag = ({ code }) => {
   const flagUrl = code === 'un'
@@ -36,7 +35,6 @@ const Flag = ({ code }) => {
 
 /**
  * A component to display one or two flags, separated by a slash.
- * @param {{codes: string[]}} props - The component props.
  */
 const FlagGroup = ({ codes }) => (
   <div className="flex items-center gap-1">
@@ -51,22 +49,70 @@ const FlagGroup = ({ codes }) => (
 );
 
 /**
+ * The dropdown menu component. It's rendered inside a portal.
+ */
+function DropdownMenu({ targetRef, onclose, getLocalizedPath }) {
+    const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
+
+    useEffect(() => {
+        if (targetRef.current) {
+            const rect = targetRef.current.getBoundingClientRect();
+            setPosition({
+                top: rect.bottom + window.scrollY,
+                left: rect.left + window.scrollX,
+                width: rect.width,
+            });
+        }
+    }, [targetRef]);
+
+    return (
+        <div
+            style={{
+                position: 'absolute',
+                top: `${position.top + 5}px`,
+                left: `${position.left}px`,
+                width: `${position.width}px`,
+            }}
+            className="origin-top-left bg-white rounded-md shadow-lg z-50">
+            <div className="py-1">
+                {languages.map(lang => (
+                    <Link
+                        key={lang.code}
+                        href={getLocalizedPath(lang.code)}
+                        onClick={onclose}
+                        className="flex items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                    >
+                        <FlagGroup codes={lang.flags} />
+                        <span>{lang.native}</span>
+                    </Link>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+
+/**
  * The main LanguageSelector component. It's a dropdown that shows the current language
  * and allows the user to select a different one.
  */
 export default function LanguageSelector() {
   const [isOpen, setIsOpen] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
   const pathname = usePathname();
-  const wrapperRef = useRef(null);
+  const buttonRef = useRef(null);
 
   // Determines the current language from the first segment of the URL path.
   const currentLangCode = pathname.split('/')[1] || 'en';
   const currentLang = languages.find(l => l.code === currentLangCode) || languages[0];
 
+  // We need to ensure the component is mounted on the client before rendering the portal.
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
   /**
    * Generates a new URL path for a given language code, preserving the rest of the path.
-   * @param {string} langCode - The target language code.
-   * @returns {string} The new, localized URL path.
    */
   const getLocalizedPath = (langCode) => {
     const pathSegments = pathname.split('/');
@@ -77,19 +123,24 @@ export default function LanguageSelector() {
   // This effect adds a click-outside listener to close the dropdown when the user clicks away.
   useEffect(() => {
     function handleClickOutside(event) {
-      if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+      if (buttonRef.current && !buttonRef.current.contains(event.target)) {
         setIsOpen(false);
       }
     }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [wrapperRef]);
+    if (isOpen) {
+        document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
 
 
   return (
-    <div className="relative" ref={wrapperRef}>
+    <div className="relative">
       {/* The button that shows the current language and toggles the dropdown */}
       <button
+        ref={buttonRef}
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center justify-between w-full px-3 py-2 text-gray-700 bg-white border rounded-md shadow-sm"
       >
@@ -102,23 +153,14 @@ export default function LanguageSelector() {
         </svg>
       </button>
 
-      {/* The dropdown menu with the list of available languages */}
-      {isOpen && (
-        <div className="absolute left-0 w-full mt-2 origin-top-left bg-white rounded-md shadow-lg z-50">
-          <div className="py-1">
-            {languages.map(lang => (
-              <Link
-                key={lang.code}
-                href={getLocalizedPath(lang.code)}
-                onClick={() => setIsOpen(false)}
-                className="flex items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-              >
-                <FlagGroup codes={lang.flags} />
-                <span>{lang.native}</span>
-              </Link>
-            ))}
-          </div>
-        </div>
+      {/* The dropdown menu is rendered into a portal to escape the parent's transform context. */}
+      {isMounted && isOpen && createPortal(
+        <DropdownMenu
+            targetRef={buttonRef}
+            onclose={() => setIsOpen(false)}
+            getLocalizedPath={getLocalizedPath}
+        />,
+        document.body
       )}
     </div>
   );


### PR DESCRIPTION
This commit implements several UX enhancements for the 'playful' theme and fixes a critical bug with the language selector.

- Refactors the LanguageSelector component to use a React Portal for its dropdown menu. This ensures the dropdown is not clipped by the parent's CSS transform context in the playful theme.
- Adds subtle hover animations (`translate-x`) to the navigation links in the playful sidebars (public and admin).
- Adds new global CSS classes for playful hover effects on cards and buttons, and applies them to the homepage for a more dynamic feel.