### PR TITLE
fix: Correct syntax error in AdminLayoutClient

### DIFF
--- a/src/components/admin/AdminLayoutClient.js
+++ b/src/components/admin/AdminLayoutClient.js
@@ -143,7 +143,8 @@ export default function AdminLayoutClient({ children }) {
         <button onClick={handleLogout} className="w-full px-4 py-2 text-left rounded hover:bg-gray-700">{t.layout.logout}</button>
       </div>
     </aside>
-  );
+    );
+  };
 
   /**
    * The topbar component, used in the 'compact' theme.


### PR DESCRIPTION
This commit fixes a build error caused by a missing closing curly brace `}` in the `Sidebar` sub-component within the `AdminLayoutClient.js` file. The error was introduced during a refactor of the component.