### PR TITLE
feat(theme): Apply playful animations to more page elements

### DIFF
--- a/src/app/[lang]/page.js
+++ b/src/app/[lang]/page.js
@@ -38,7 +38,7 @@ export default async function HomePage({ params: { lang } }) {
     <div className="space-y-16">
       {/* Hero Section */}
       <AnimatedSection>
-        <section className="text-center bg-white p-12 rounded-lg shadow-lg">
+        <section className="playful-card text-center bg-white p-12 rounded-lg shadow-lg">
           <h1 className="text-5xl font-extrabold text-gray-900 font-header">{t.homePage.heroTitle}</h1>
           <p className="mt-4 text-xl text-text/80 max-w-2xl mx-auto">{t.homePage.heroSubtitle}</p>
           <div className="mt-8">

--- a/src/app/[lang]/pricing/page.js
+++ b/src/app/[lang]/pricing/page.js
@@ -5,7 +5,7 @@ export default async function PricingPage({ params: { lang } }) {
   const t = await getTranslations(lang);
 
   return (
-    <div className="bg-white p-12 rounded-lg shadow-lg">
+    <div className="playful-card bg-white p-12 rounded-lg shadow-lg">
       <h1 className="text-4xl font-extrabold text-center text-gray-900 font-header">{t.pricingPage.title}</h1>
 
       <div className="max-w-4xl mx-auto mt-8 space-y-8 text-lg text-text/90">


### PR DESCRIPTION
This commit extends the playful theme's hover animations to more content boxes across the site.

The `playful-card` class, which provides a lift-and-shadow effect on hover, has been added to the main content containers on the homepage and the pricing page to create a more consistent and interactive user experience.