### PR TITLE
fix(admin): Refactor sidebar navigation for single-page theme

### DIFF
--- a/src/components/admin/AdminLayoutClient.js
+++ b/src/components/admin/AdminLayoutClient.js
@@ -127,35 +127,51 @@ export default function AdminLayoutClient({ children }) {
    * The sidebar component, used in 'default' and 'playful' themes.
    */
   const Sidebar = () => {
-    const playfulLinkClasses = "block px-4 py-2 rounded hover:bg-indigo-700 transition-all duration-200 hover:translate-x-2";
-    const defaultLinkClasses = (href) => {
-        const base = "block px-4 py-2 rounded";
-        const hover = "hover:bg-gray-700";
-        const active = pathname.startsWith(href) ? "bg-primary" : "";
-        return `${base} ${hover} ${active}`;
+    // This is the navigation for the 'single-page' theme.
+    // It renders `<a>` tags with a scroll handler.
+    const SinglePageNav = () => (
+      <nav className="flex-grow p-4 space-y-2">
+        {navLinks.map(link => {
+          // The "Change Password" link is a normal link, not a scroll link.
+          if (link.id === 'password') {
+            return <Link key={link.id} href={link.href} className={navLinkClasses(link.href)}>{link.label}</Link>;
+          }
+          // All other links scroll to sections on the dashboard page.
+          return (
+            <a key={link.id} href={`/fonok/dashboard#${link.id}`} onClick={(e) => handleScrollTo(e, link.id)} className={navLinkClasses(link.href)}>
+              {link.label}
+            </a>
+          );
+        })}
+      </nav>
+    );
+
+    // This is the navigation for all other themes ('default', 'playful').
+    // It renders standard Next.js <Link> components for page navigation.
+    const MultiPageNav = () => {
+        const playfulLinkClasses = "block px-4 py-2 rounded hover:bg-indigo-700 transition-all duration-200 hover:translate-x-2";
+        return (
+            <nav className="flex-grow p-4 space-y-2">
+                {navLinks.map(link => (
+                    <Link key={link.href} href={link.href} className={appearance === 'playful' ? playfulLinkClasses : navLinkClasses(link.href)}>{link.label}</Link>
+                ))}
+            </nav>
+        );
     };
 
     return (
-    <aside className={asideClasses[appearance]}>
-      <div className={`p-4 text-xl font-bold border-b ${appearance === 'playful' ? 'border-indigo-700' : 'border-gray-700'}`}>{t.layout.title}</div>
-      <nav className="flex-grow p-4 space-y-2">
-        {navLinks.map(link => {
-            if (appearance === 'single-page') {
-                // If it's a single page, all links go to the dashboard but scroll to a section.
-                // The "Change Password" link still goes to its own page.
-                const href = link.id === 'password' ? link.href : `/fonok/dashboard#${link.id}`;
-                return <a key={link.id} href={href} onClick={(e) => handleScrollTo(e, link.id)} className={defaultLinkClasses(link.href)}>{link.label}</a>
-            }
-            return <Link key={link.href} href={link.href} className={appearance === 'playful' ? playfulLinkClasses : defaultLinkClasses(link.href)}>{link.label}</Link>
-        })}
-      </nav>
-      <div className={`p-4 border-t ${appearance === 'playful' ? 'border-indigo-700' : 'border-gray-700'}`}>
-        <AdminLangSelector />
-      </div>
-      <div className={`p-4 border-t ${appearance === 'playful' ? 'border-indigo-700' : 'border-gray-700'}`}>
-        <button onClick={handleLogout} className="w-full px-4 py-2 text-left rounded hover:bg-gray-700">{t.layout.logout}</button>
-      </div>
-    </aside>
+      <aside className={asideClasses[appearance]}>
+        <div className={`p-4 text-xl font-bold border-b ${appearance === 'playful' ? 'border-indigo-700' : 'border-gray-700'}`}>{t.layout.title}</div>
+
+        {appearance === 'single-page' ? <SinglePageNav /> : <MultiPageNav />}
+
+        <div className={`p-4 border-t ${appearance === 'playful' ? 'border-indigo-700' : 'border-gray-700'}`}>
+          <AdminLangSelector />
+        </div>
+        <div className={`p-4 border-t ${appearance === 'playful' ? 'border-indigo-700' : 'border-gray-700'}`}>
+          <button onClick={handleLogout} className="w-full px-4 py-2 text-left rounded hover:bg-gray-700">{t.layout.logout}</button>
+        </div>
+      </aside>
     );
   };
 


### PR DESCRIPTION
This commit implements a robust fix for the single-page admin theme's navigation.

The `Sidebar` component in `AdminLayoutClient.js` has been refactored to use a top-level conditional check for the 'single-page' theme. It now renders a dedicated navigation block with anchor links and smooth-scroll handlers for this theme, while rendering standard Next.js links for all other themes.

This ensures the navigation behavior is correct and reliable for all themes and resolves the long-standing issue with the single-page admin UI.