### PR TITLE
feat(admin): Implement horizontal nav for single-page theme

### DIFF
--- a/src/components/admin/AdminAppearanceEditor.js
+++ b/src/components/admin/AdminAppearanceEditor.js
@@ -109,12 +109,24 @@ export default function AdminAppearanceEditor() {
     if (success) {
       const successMsg = t.appearance.success.replace('{themeName}', themeName).replace('{target}', target);
       setMessage(successMsg);
+
+      // If the admin theme was changed to single-page, reload to the dashboard
+      if ((target === 'admin' || target === 'both') && selectedTheme === 'single-page') {
+        setTimeout(() => {
+            window.location.href = '/fonok/dashboard';
+        }, 1000);
+      } else {
+        // Clear the message after 5 seconds if not redirecting
+        setTimeout(() => setMessage(''), 5000);
+      }
     } else {
       setMessage(t.appearance.error);
+      setIsSaving(false);
     }
-    setIsSaving(false);
-    // Clear the message after 5 seconds.
-    setTimeout(() => setMessage(''), 5000);
+    // We only set isSaving to false here for the success case if we are not redirecting
+    if (!((target === 'admin' || target === 'both') && selectedTheme === 'single-page')) {
+      setIsSaving(false);
+    }
   };
 
   const themeName = themes.find(t => t.id === selectedTheme)?.name || 'N/A';


### PR DESCRIPTION
This commit completes the implementation of the single-page admin theme.

- Refactors `AdminLayoutClient.js` to render a horizontal `Topbar` instead of a `Sidebar` when the 'single-page' theme is active. This `Topbar` contains the correct smooth-scrolling anchor links.
- Modifies `AdminAppearanceEditor.js` to force a page reload to the dashboard after the admin theme is set to 'single-page'. This ensures the user is on the correct page for the new single-page layout to work correctly.