### PR TITLE
feat(admin): Integrate change password form into single-page theme

### DIFF
--- a/src/app/fonok/change-password/page.js
+++ b/src/app/fonok/change-password/page.js
@@ -2,13 +2,21 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useAdminTranslations } from '@/components/admin/AdminTranslationsProvider';
 
-export default function ChangePasswordPage() {
+export function ChangePasswordSection({ isSection = false }) {
+  const [oldPassword, setOldPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
+  const { t } = useAdminTranslations();
+
+  // This is a simple check to see if the user was forced here.
+  // A more robust solution might use a query param or state management.
+  const isForced = typeof window !== 'undefined' && window.history.length <= 2;
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -16,85 +24,78 @@ export default function ChangePasswordPage() {
     setSuccess('');
 
     if (newPassword !== confirmPassword) {
-      setError('Passwords do not match.');
+      setError(t.changePassword.errorMatch);
+      return;
+    }
+    if (newPassword.length < 6) {
+      setError(t.changePassword.errorLength);
       return;
     }
 
+    setIsSubmitting(true);
     try {
       const res = await fetch('/api/auth/change-password', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ newPassword }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ oldPassword: isForced ? '' : oldPassword, newPassword }),
       });
 
       const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Something went wrong');
 
-      if (!res.ok) {
-        throw new Error(data.message || 'Failed to change password');
-      }
-
-      setSuccess('Password updated successfully! Redirecting to dashboard...');
+      setSuccess(t.changePassword.success);
       setTimeout(() => {
         router.push('/fonok/dashboard');
-      }, 2000);
+      }, 1500);
 
     } catch (err) {
       setError(err.message);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
+  const formContent = (
+    <div className="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-md">
+      <h1 className="text-2xl font-bold text-center text-gray-900">
+        {isForced && !isSection ? t.changePassword.title : t.changePassword.titleLoggedIn}
+      </h1>
+      {isForced && !isSection && <p className="text-center text-sm text-gray-600">{t.changePassword.intro}</p>}
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {!isForced && (
+          <div>
+            <label htmlFor="oldPassword"className="text-sm font-medium text-gray-700">Current Password</label>
+            <input id="oldPassword" name="oldPassword" type="password" value={oldPassword} onChange={(e) => setOldPassword(e.target.value)} required className="mt-1 block w-full px-3 py-2 border rounded-md" />
+          </div>
+        )}
+        <div>
+          <label htmlFor="newPassword"className="text-sm font-medium text-gray-700">{t.changePassword.newPasswordLabel}</label>
+          <input id="newPassword" name="newPassword" type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required className="mt-1 block w-full px-3 py-2 border rounded-md" />
+        </div>
+        <div>
+          <label htmlFor="confirmPassword"className="text-sm font-medium text-gray-700">{t.changePassword.confirmPasswordLabel}</label>
+          <input id="confirmPassword" name="confirmPassword" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required className="mt-1 block w-full px-3 py-2 border rounded-md" />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        {success && <p className="text-sm text-green-600">{success}</p>}
+        <div>
+          <button type="submit" disabled={isSubmitting} className="w-full px-4 py-2 text-white bg-cyan-600 rounded-md disabled:bg-gray-400">
+            {isSubmitting ? 'Saving...' : t.changePassword.button}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+
+  if (isSection) {
+    return formContent;
+  }
+
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      <div className="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-md">
-        <h1 className="text-2xl font-bold text-center text-gray-900">Change Your Password</h1>
-        <p className="text-sm text-center text-gray-600">As a security measure, you must change the default password.</p>
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <div>
-            <label
-              htmlFor="newPassword"
-              className="text-sm font-medium text-gray-700"
-            >
-              New Password
-            </label>
-            <input
-              id="newPassword"
-              type="password"
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-              required
-              className="block w-full px-3 py-2 mt-1 text-gray-900 placeholder-gray-500 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-cyan-500 focus:border-cyan-500 sm:text-sm"
-            />
-          </div>
-          <div>
-            <label
-              htmlFor="confirmPassword"
-              className="text-sm font-medium text-gray-700"
-            >
-              Confirm New Password
-            </label>
-            <input
-              id="confirmPassword"
-              type="password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              required
-              className="block w-full px-3 py-2 mt-1 text-gray-900 placeholder-gray-500 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-cyan-500 focus:border-cyan-500 sm:text-sm"
-            />
-          </div>
-          {error && <p className="text-sm text-red-600">{error}</p>}
-          {success && <p className="text-sm text-green-600">{success}</p>}
-          <div>
-            <button
-              type="submit"
-              className="w-full px-4 py-2 text-sm font-medium text-white bg-cyan-600 border border-transparent rounded-md shadow-sm hover:bg-cyan-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500"
-            >
-              Set New Password
-            </button>
-          </div>
-        </form>
-      </div>
+      {formContent}
     </div>
   );
 }
+
+export default ChangePasswordSection;

--- a/src/app/fonok/dashboard/page.js
+++ b/src/app/fonok/dashboard/page.js
@@ -7,6 +7,7 @@ import { TripsSection } from '../trips/page.js';
 import { ArticlesSection } from '../articles/page.js';
 import { SettingsSection } from '../settings/page.js';
 import { StylingSection } from '../styling/page.js';
+import { ChangePasswordSection } from '../change-password/page.js';
 
 function DashboardWelcome() {
   const { t } = useAdminTranslations();
@@ -65,6 +66,10 @@ export default function DashboardPage() {
       <hr />
       <section id="styling">
         <StylingSection />
+      </section>
+      <hr />
+      <section id="password">
+        <ChangePasswordSection isSection={true} />
       </section>
     </div>
   );

--- a/src/components/admin/AdminLayoutClient.js
+++ b/src/components/admin/AdminLayoutClient.js
@@ -159,9 +159,6 @@ export default function AdminLayoutClient({ children }) {
   const Topbar = () => {
     const navContent = navLinks.map(link => {
         if (appearance === 'single-page') {
-            if (link.id === 'password') {
-                return <Link key={link.id} href={link.href} className={`text-sm ${pathname.startsWith(link.href) ? 'text-primary font-bold' : 'text-gray-600'}`}>{link.label}</Link>;
-            }
             return <a key={link.id} href={`/fonok/dashboard#${link.id}`} onClick={(e) => handleScrollTo(e, link.id)} className="text-sm text-gray-600 hover:text-primary">{link.label}</a>
         }
         // Logic for 'compact' theme


### PR DESCRIPTION
This commit completes the single-page admin theme by integrating the 'Change Password' form as a scrollable section within the dashboard page.

- The `change-password` page component has been refactored to be a self-contained section.
- The dashboard page now imports and renders the `ChangePasswordSection`.
- The navigation logic in `AdminLayoutClient` has been updated to remove the special case for the password link, making it a standard scrolling anchor link in the single-page theme.